### PR TITLE
Added passing of auth object into soap call

### DIFF
--- a/upnpclient/soap.py
+++ b/upnpclient/soap.py
@@ -71,7 +71,7 @@ class SOAP(object):
         xml_str = re.sub(r'<\?xml.*?\?>', '', xml_str, flags=re.I)
         return xml_declaration + xml_str
 
-    def call(self, action_name, arg_in=None):
+    def call(self, action_name, arg_in=None, http_auth=None):
         """
         Construct the XML and make the call to the device. Parse the response values into a dict.
         """
@@ -96,7 +96,7 @@ class SOAP(object):
         }
 
         try:
-            resp = requests.post(self.url, body, headers=headers, timeout=SOAP_TIMEOUT)
+            resp = requests.post(self.url, body, headers=headers, timeout=SOAP_TIMEOUT, auth=http_auth)
             resp.raise_for_status()
         except requests.exceptions.HTTPError as exc:
             # If the body of the error response contains XML then it should be a UPnP error,

--- a/upnpclient/soap.py
+++ b/upnpclient/soap.py
@@ -96,7 +96,8 @@ class SOAP(object):
         }
 
         try:
-            resp = requests.post(self.url, body, headers=headers, timeout=SOAP_TIMEOUT, auth=http_auth)
+            resp = requests.post(self.url, body, headers=headers,
+                                 timeout=SOAP_TIMEOUT, auth=http_auth)
             resp.raise_for_status()
         except requests.exceptions.HTTPError as exc:
             # If the body of the error response contains XML then it should be a UPnP error,

--- a/upnpclient/upnp.py
+++ b/upnpclient/upnp.py
@@ -417,7 +417,12 @@ class Action(object):
 
         # Make the actual call
         soap_client = SOAP(self.url, self.service_type)
-        soap_response = soap_client.call(self.name, call_kwargs)
+
+        # pass auth object to call if it is set
+        if 'auth' in kwargs:
+            soap_response = soap_client.call(self.name, call_kwargs, kwargs['auth'])
+        else:
+            soap_response = soap_client.call(self.name, call_kwargs)
 
         # Marshall the response to python data types
         out = {}

--- a/upnpclient/upnp.py
+++ b/upnpclient/upnp.py
@@ -82,7 +82,7 @@ class Device(CallActionMixin):
     urn:upnp-org:serviceId:wandsllc:pvc_Internet
     urn:upnp-org:serviceId:wanipc:Internet
     """
-    def __init__(self, location, device_name=None, ignore_urlbase=False):
+    def __init__(self, location, device_name=None, ignore_urlbase=False, http_auth=None):
         """
         Create a new Device instance. `location` is an URL to an XML file
         describing the server's services.
@@ -93,7 +93,9 @@ class Device(CallActionMixin):
         self.service_map = {}
         self._log = _getLogger('Device')
 
-        resp = requests.get(location, timeout=HTTP_TIMEOUT)
+        self.http_auth = http_auth
+
+        resp = requests.get(location, timeout=HTTP_TIMEOUT, auth=self.http_auth)
         resp.raise_for_status()
 
         root = etree.fromstring(resp.content)
@@ -214,7 +216,7 @@ class Service(CallActionMixin):
 
         url = urljoin(self._url_base, self.scpd_url)
         self._log.info('Reading %s', url)
-        resp = requests.get(url, timeout=HTTP_TIMEOUT)
+        resp = requests.get(url, timeout=HTTP_TIMEOUT, auth=self.device.http_auth)
         resp.raise_for_status()
         self.scpd_xml = etree.fromstring(resp.content)
         self._find = partial(self.scpd_xml.find, namespaces=self.scpd_xml.nsmap)
@@ -350,7 +352,7 @@ class Service(CallActionMixin):
         )
         if timeout is not None:
             headers['TIMEOUT'] = 'Second-%s' % timeout
-        resp = requests.request('SUBSCRIBE', url, headers=headers)
+        resp = requests.request('SUBSCRIBE', url, headers=headers, auth=self.device.http_auth)
         resp.raise_for_status()
         return Service.validate_subscription_response(resp)
 
@@ -365,7 +367,7 @@ class Service(CallActionMixin):
         )
         if timeout is not None:
             headers['TIMEOUT'] = 'Second-%s' % timeout
-        resp = requests.request('SUBSCRIBE', url, headers=headers)
+        resp = requests.request('SUBSCRIBE', url, headers=headers, auth=self.device.http_auth)
         resp.raise_for_status()
         return Service.validate_subscription_renewal_response(resp)
 
@@ -378,7 +380,7 @@ class Service(CallActionMixin):
             HOST=urlparse(url).netloc,
             SID=sid
         )
-        resp = requests.request('UNSUBSCRIBE', url, headers=headers)
+        resp = requests.request('UNSUBSCRIBE', url, headers=headers, auth=self.device.http_auth)
         resp.raise_for_status()
 
 
@@ -399,7 +401,7 @@ class Action(object):
     def __repr__(self):
         return "<Action '%s'>" % (self.name)
 
-    def __call__(self, **kwargs):
+    def __call__(self, http_auth=None, **kwargs):
         arg_reasons = {}
         call_kwargs = OrderedDict()
         # Validate arguments using the SCPD stateVariable definitions
@@ -418,11 +420,9 @@ class Action(object):
         # Make the actual call
         soap_client = SOAP(self.url, self.service_type)
 
-        # pass auth object to call if it is set
-        if 'auth' in kwargs:
-            soap_response = soap_client.call(self.name, call_kwargs, kwargs['auth'])
-        else:
-            soap_response = soap_client.call(self.name, call_kwargs)
+        # pass a requests auth object if either the device or the http_auth argument supply one
+        auth_object = http_auth or self.service.device.http_auth
+        soap_response = soap_client.call(self.name, call_kwargs, auth_object)
 
         # Marshall the response to python data types
         out = {}


### PR DESCRIPTION
I have been using this library to interact with a fritzbox lately and it requires http digest authentication for quite a big amount of SOAP calls so i made some small changes to this library that allow the passing of the [requests auth object](http://docs.python-requests.org/en/master/user/authentication/) via the call kwargs of the Action.

This short snipped shows what is currently supported:
```
dev = upnpclient.Device("http://192.168.178.1:49000/tr64desc.xml")
dev['X_AVM-DE_TAM1'].GetMessageList(NewIndex=0, auth=HTTPDigestAuth('username', 'password'))
``` 
Another approach would be setting the auth object on the Device object and passing it down to every call although i am not quite sure which one would be most sensible. Let me know what you think would make sense.
