### PR TITLE
Fix gathering of nic ip addresses

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ requests
 six
 python-dateutil
 lxml
+ifaddr


### PR DESCRIPTION
The first and most important PR: Fixing how IP addresses are gathered by the function **get_all_address()**

**Problem:** 
The current implementation of **get_all_address()** is flat-out wrong!

`[addr[-1][0] for addr in socket.getaddrinfo(socket.gethostname(), None, socket.AF_INET)]`

Quote from the _socket_ documentation for the function _getaddrinfo()_:

> Translate the host/port argument into a sequence of 5-tuples that contain all the necessary arguments for creating a socket connected to that service.

That means that the current code will just get the IP from our host, which will be a localhost address(!) and nothing else. Obviously that is not correct.

Example:
```
Python 3.7.3 (default, Jul 25 2020, 13:03:44)
[GCC 8.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from upnpclient import ssdp
>>> ssdp.get_all_address()
['127.0.1.1', '127.0.1.1', '127.0.1.1']
>>>
```

**Solution:**
I found a special library which has the sole purpose to collect the IP addresses of a computer.
[ifaddr](https://pypi.org/project/ifaddr/) is a cross platform library under the MIT license for Python 2.7 and 3.5+ which works at least on **Linux, OS X, and Windows**. **BSD** should work too, but is not tested by the author himself. 

Thanks to this library one is easily capable to extract the IP addresses of the machine. I renamed the function **get_addresses_ipv4()** to make it more descriptive

Example:
```
Python 3.7.3 (default, Jul 25 2020, 13:03:44)
[GCC 8.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from upnpclient import ssdp
>>> ssdp.get_addresses_ipv4()
['192.168.43.199']
>>>
```

Please have a look at this PR and let me know your thoughts of these changes :)