### PR TITLE
Fix error because of stripping from None

### DIFF
--- a/upnpclient/upnp.py
+++ b/upnpclient/upnp.py
@@ -114,7 +114,7 @@ class Device(CallActionMixin):
         resp.raise_for_status()
 
         root = etree.fromstring(resp.content)
-        findtext = partial(root.findtext, namespaces=root.nsmap)
+        findtext = partial(root.findtext, namespaces=root.nsmap, default="")
 
         self.device_type = findtext("device/deviceType").strip()
         self.friendly_name = findtext("device/friendlyName").strip()
@@ -127,7 +127,7 @@ class Device(CallActionMixin):
         self.udn = findtext("device/UDN").strip()
 
         self._url_base = findtext("URLBase").strip()
-        if self._url_base is None or ignore_urlbase:
+        if self._url_base == "" or ignore_urlbase:
             # If no URL Base is given, the UPnP specification says: "the base
             # URL is the URL from which the device description was retrieved"
             self._url_base = self.location


### PR DESCRIPTION
This is a rather small but very important fix regarding the device attributes.

One of the newest additions to this library was to **.strip()** every attribute from the devices XML file.
```
self.device_type = findtext("device/deviceType").strip()
self.friendly_name = findtext("device/friendlyName").strip()
self.manufacturer = findtext("device/manufacturer").strip()
self.manufacturer_url = findtext("device/manufacturerURL").strip()
self.model_description = findtext("device/modelDescription").strip()
self.model_name = findtext("device/modelName").strip()
self.model_number = findtext("device/modelNumber").strip()
self.serial_number = findtext("device/serialNumber").strip()
self.udn = findtext("device/UDN").strip()

self._url_base = findtext("URLBase").strip()
```
Sadly this change introduced another bug, which prevents the usage of many devices.

If an attribute of a device could not be found, the return value of **findtext** defaults to None. And doing a **.strip()** from a None value will throw an error and therefore renders the device useless. Due to the fact that many devices do not implement all attributes, this bug can be seen as rather important to fix.

That this one slipped through is actual pretty funny, because the code and comment for **self._url_base** is aware that it can return a None value:
```
self._url_base = findtext("URLBase").strip()
if self._url_base is None or ignore_urlbase:
    # If no URL Base is given, the UPnP specification says: "the base
    # URL is the URL from which the device description was retrieved"
    self._url_base = self.location
```

Anyway, the fix is pretty simple. The **findtext** method from the **etree** module can accept a default value. We will just pass an empty string as default value. By doing that the **.strip()** won't throw and error and the programmer just gets an empty string when trying to retrieve that attribute from the device.

Have a nice day!