### PR TITLE
Add asyncio compatability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,6 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# VSCode
+settings.json

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,163 +1,189 @@
 [[package]]
-category = "dev"
-description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
-name = "appdirs"
+name = "aiohttp"
+version = "3.7.3"
+description = "Async http client/server framework (asyncio)"
+category = "main"
 optional = false
-python-versions = "*"
-version = "1.4.4"
+python-versions = ">=3.6"
 
-[[package]]
-category = "dev"
-description = "Atomic file writes."
-marker = "sys_platform == \"win32\""
-name = "atomicwrites"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "1.4.0"
-
-[[package]]
-category = "dev"
-description = "Classes Without Boilerplate"
-name = "attrs"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "19.3.0"
+[package.dependencies]
+async-timeout = ">=3.0,<4.0"
+attrs = ">=17.3.0"
+chardet = ">=2.0,<4.0"
+idna-ssl = {version = ">=1.0", markers = "python_version < \"3.7\""}
+multidict = ">=4.5,<7.0"
+typing-extensions = ">=3.6.5"
+yarl = ">=1.0,<2.0"
 
 [package.extras]
-azure-pipelines = ["coverage", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "pytest-azurepipelines"]
-dev = ["coverage", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "sphinx", "pre-commit"]
-docs = ["sphinx", "zope.interface"]
-tests = ["coverage", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface"]
+speedups = ["aiodns", "brotlipy", "cchardet"]
 
 [[package]]
-category = "main"
-description = "Python package for providing Mozilla's CA Bundle."
-name = "certifi"
-optional = false
-python-versions = "*"
-version = "2020.4.5.1"
-
-[[package]]
-category = "main"
-description = "Universal encoding detector for Python 2 and 3"
-name = "chardet"
-optional = false
-python-versions = "*"
-version = "3.0.4"
-
-[[package]]
+name = "appdirs"
+version = "1.4.4"
+description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 category = "dev"
-description = "Cross-platform colored terminal text."
-marker = "sys_platform == \"win32\" or platform_system == \"Windows\""
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "async-timeout"
+version = "3.0.1"
+description = "Timeout context manager for asyncio programs"
+category = "main"
+optional = false
+python-versions = ">=3.5.3"
+
+[[package]]
+name = "atomicwrites"
+version = "1.4.0"
+description = "Atomic file writes."
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "attrs"
+version = "20.3.0"
+description = "Classes Without Boilerplate"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[package.extras]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "furo", "sphinx", "pre-commit"]
+docs = ["furo", "sphinx", "zope.interface"]
+tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface"]
+tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six"]
+
+[[package]]
+name = "certifi"
+version = "2020.11.8"
+description = "Python package for providing Mozilla's CA Bundle."
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "chardet"
+version = "3.0.4"
+description = "Universal encoding detector for Python 2 and 3"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "colorama"
+version = "0.4.4"
+description = "Cross-platform colored terminal text."
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "0.4.3"
 
 [[package]]
-category = "dev"
-description = "Code coverage measurement for Python"
 name = "coverage"
+version = "5.3"
+description = "Code coverage measurement for Python"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
-version = "5.1"
 
 [package.extras]
 toml = ["toml"]
 
 [[package]]
-category = "dev"
-description = "Distribution utilities"
 name = "distlib"
+version = "0.3.1"
+description = "Distribution utilities"
+category = "dev"
 optional = false
 python-versions = "*"
-version = "0.3.0"
 
 [[package]]
-category = "dev"
-description = "A platform independent file lock."
 name = "filelock"
+version = "3.0.12"
+description = "A platform independent file lock."
+category = "dev"
 optional = false
 python-versions = "*"
-version = "3.0.12"
 
 [[package]]
-category = "dev"
-description = "the modular source code checker: pep8 pyflakes and co"
 name = "flake8"
+version = "3.8.4"
+description = "the modular source code checker: pep8 pyflakes and co"
+category = "dev"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
-version = "3.8.2"
 
 [package.dependencies]
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 mccabe = ">=0.6.0,<0.7.0"
 pycodestyle = ">=2.6.0a1,<2.7.0"
 pyflakes = ">=2.2.0,<2.3.0"
 
-[package.dependencies.importlib-metadata]
-python = "<3.8"
-version = "*"
-
 [[package]]
-category = "main"
-description = "Internationalized Domain Names in Applications (IDNA)"
 name = "idna"
+version = "2.10"
+description = "Internationalized Domain Names in Applications (IDNA)"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "2.9"
 
 [[package]]
+name = "idna-ssl"
+version = "1.1.0"
+description = "Patch ssl.match_hostname for Unicode(idna) domains support"
 category = "main"
-description = "Cross-platform network interface and IP address enumeration library"
-name = "ifaddr"
 optional = false
 python-versions = "*"
-version = "0.1.7"
+
+[package.dependencies]
+idna = ">=2.0"
 
 [[package]]
-category = "dev"
-description = "Read metadata from Python packages"
-marker = "python_version < \"3.8\""
+name = "ifaddr"
+version = "0.1.7"
+description = "Cross-platform network interface and IP address enumeration library"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "importlib-metadata"
+version = "2.1.1"
+description = "Read metadata from Python packages"
+category = "dev"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
-version = "1.6.0"
 
 [package.dependencies]
 zipp = ">=0.5"
 
 [package.extras]
 docs = ["sphinx", "rst.linker"]
-testing = ["packaging", "importlib-resources"]
+testing = ["packaging", "pep517", "unittest2", "importlib-resources (>=1.3)"]
 
 [[package]]
-category = "dev"
-description = "Read resources from Python packages"
-marker = "python_version < \"3.7\""
 name = "importlib-resources"
+version = "3.3.0"
+description = "Read resources from Python packages"
+category = "dev"
 optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
-version = "1.5.0"
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
 
 [package.dependencies]
-[package.dependencies.importlib-metadata]
-python = "<3.8"
-version = "*"
-
-[package.dependencies.zipp]
-python = "<3.8"
-version = ">=0.4"
+zipp = {version = ">=0.4", markers = "python_version < \"3.8\""}
 
 [package.extras]
 docs = ["sphinx", "rst.linker", "jaraco.packaging"]
 
 [[package]]
-category = "main"
-description = "Powerful and Pythonic XML processing library combining libxml2/libxslt with the ElementTree API."
 name = "lxml"
+version = "4.6.2"
+description = "Powerful and Pythonic XML processing library combining libxml2/libxslt with the ElementTree API."
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, != 3.4.*"
-version = "4.5.1"
 
 [package.extras]
 cssselect = ["cssselect (>=0.7)"]
@@ -166,20 +192,20 @@ htmlsoup = ["beautifulsoup4"]
 source = ["Cython (>=0.29.7)"]
 
 [[package]]
-category = "dev"
-description = "McCabe checker, plugin for flake8"
 name = "mccabe"
+version = "0.6.1"
+description = "McCabe checker, plugin for flake8"
+category = "dev"
 optional = false
 python-versions = "*"
-version = "0.6.1"
 
 [[package]]
-category = "dev"
-description = "Rolling backport of unittest.mock for all Pythons"
 name = "mock"
+version = "4.0.2"
+description = "Rolling backport of unittest.mock for all Pythons"
+category = "dev"
 optional = false
 python-versions = ">=3.6"
-version = "4.0.2"
 
 [package.extras]
 build = ["twine", "wheel", "blurb"]
@@ -187,170 +213,173 @@ docs = ["sphinx"]
 test = ["pytest", "pytest-cov"]
 
 [[package]]
-category = "dev"
-description = "More routines for operating on iterables, beyond itertools"
 name = "more-itertools"
+version = "8.6.0"
+description = "More routines for operating on iterables, beyond itertools"
+category = "dev"
 optional = false
 python-versions = ">=3.5"
-version = "8.3.0"
 
 [[package]]
-category = "dev"
-description = "Core utilities for Python packages"
+name = "multidict"
+version = "5.1.0"
+description = "multidict implementation"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
 name = "packaging"
+version = "20.7"
+description = "Core utilities for Python packages"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "20.4"
 
 [package.dependencies]
 pyparsing = ">=2.0.2"
-six = "*"
 
 [[package]]
-category = "dev"
-description = "plugin and hook calling mechanisms for python"
 name = "pluggy"
+version = "0.13.1"
+description = "plugin and hook calling mechanisms for python"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "0.13.1"
 
 [package.dependencies]
-[package.dependencies.importlib-metadata]
-python = "<3.8"
-version = ">=0.12"
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 
 [package.extras]
 dev = ["pre-commit", "tox"]
 
 [[package]]
-category = "dev"
-description = "library with cross-python path, ini-parsing, io, code, log facilities"
 name = "py"
+version = "1.9.0"
+description = "library with cross-python path, ini-parsing, io, code, log facilities"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "1.8.1"
 
 [[package]]
-category = "dev"
-description = "Python style guide checker"
 name = "pycodestyle"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "2.6.0"
-
-[[package]]
+description = "Python style guide checker"
 category = "dev"
-description = "passive checker of Python programs"
-name = "pyflakes"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "2.2.0"
 
 [[package]]
+name = "pyflakes"
+version = "2.2.0"
+description = "passive checker of Python programs"
 category = "dev"
-description = "Python parsing module"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
 name = "pyparsing"
+version = "2.4.7"
+description = "Python parsing module"
+category = "dev"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
-version = "2.4.7"
 
 [[package]]
-category = "dev"
-description = "pytest: simple powerful testing with Python"
 name = "pytest"
+version = "5.4.3"
+description = "pytest: simple powerful testing with Python"
+category = "dev"
 optional = false
 python-versions = ">=3.5"
-version = "5.4.3"
 
 [package.dependencies]
-atomicwrites = ">=1.0"
+atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
 attrs = ">=17.4.0"
-colorama = "*"
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 more-itertools = ">=4.0.0"
 packaging = "*"
 pluggy = ">=0.12,<1.0"
 py = ">=1.5.0"
 wcwidth = "*"
 
-[package.dependencies.importlib-metadata]
-python = "<3.8"
-version = ">=0.12"
-
 [package.extras]
-checkqa-mypy = ["mypy (v0.761)"]
+checkqa-mypy = ["mypy (==v0.761)"]
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
 
 [[package]]
-category = "dev"
-description = "Pytest plugin for measuring coverage."
 name = "pytest-cov"
+version = "2.10.1"
+description = "Pytest plugin for measuring coverage."
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "2.9.0"
 
 [package.dependencies]
 coverage = ">=4.4"
-pytest = ">=3.6"
+pytest = ">=4.6"
 
 [package.extras]
-testing = ["fields", "hunter", "process-tests (2.0.2)", "six", "pytest-xdist", "virtualenv"]
+testing = ["fields", "hunter", "process-tests (==2.0.2)", "six", "pytest-xdist", "virtualenv"]
 
 [[package]]
-category = "main"
-description = "Extensions to the standard Python datetime module"
 name = "python-dateutil"
+version = "2.8.1"
+description = "Extensions to the standard Python datetime module"
+category = "main"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
-version = "2.8.1"
 
 [package.dependencies]
 six = ">=1.5"
 
 [[package]]
-category = "main"
-description = "Python HTTP for Humans."
 name = "requests"
+version = "2.25.0"
+description = "Python HTTP for Humans."
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "2.23.0"
 
 [package.dependencies]
 certifi = ">=2017.4.17"
 chardet = ">=3.0.2,<4"
 idna = ">=2.5,<3"
-urllib3 = ">=1.21.1,<1.25.0 || >1.25.0,<1.25.1 || >1.25.1,<1.26"
+urllib3 = ">=1.21.1,<1.27"
 
 [package.extras]
 security = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)"]
-socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7)", "win-inet-pton"]
+socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
 
 [[package]]
-category = "main"
-description = "Python 2 and 3 compatibility utilities"
 name = "six"
+version = "1.15.0"
+description = "Python 2 and 3 compatibility utilities"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
-version = "1.15.0"
 
 [[package]]
-category = "dev"
-description = "Python Library for Tom's Obvious, Minimal Language"
 name = "toml"
+version = "0.10.2"
+description = "Python Library for Tom's Obvious, Minimal Language"
+category = "dev"
 optional = false
-python-versions = "*"
-version = "0.10.1"
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
-category = "dev"
-description = "tox is a generic virtualenv management and test command line tool"
 name = "tox"
+version = "3.20.1"
+description = "tox is a generic virtualenv management and test command line tool"
+category = "dev"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
-version = "3.15.1"
 
 [package.dependencies]
-colorama = ">=0.4.1"
+colorama = {version = ">=0.4.1", markers = "platform_system == \"Windows\""}
 filelock = ">=3.0.0"
+importlib-metadata = {version = ">=0.12,<3", markers = "python_version < \"3.8\""}
 packaging = ">=14"
 pluggy = ">=0.12.0"
 py = ">=1.4.17"
@@ -358,192 +387,262 @@ six = ">=1.14.0"
 toml = ">=0.9.4"
 virtualenv = ">=16.0.0,<20.0.0 || >20.0.0,<20.0.1 || >20.0.1,<20.0.2 || >20.0.2,<20.0.3 || >20.0.3,<20.0.4 || >20.0.4,<20.0.5 || >20.0.5,<20.0.6 || >20.0.6,<20.0.7 || >20.0.7"
 
-[package.dependencies.importlib-metadata]
-python = "<3.8"
-version = ">=0.12,<2"
-
 [package.extras]
-docs = ["sphinx (>=2.0.0)", "towncrier (>=18.5.0)", "pygments-github-lexers (>=0.0.5)", "sphinxcontrib-autoprogram (>=0.1.5)"]
-testing = ["freezegun (>=0.3.11)", "pathlib2 (>=2.3.3)", "pytest (>=4.0.0)", "pytest-cov (>=2.5.1)", "pytest-mock (>=1.10.0)", "pytest-xdist (>=1.22.2)", "pytest-randomly (>=1.0.0)", "flaky (>=3.4.0)", "psutil (>=5.6.1)"]
+docs = ["pygments-github-lexers (>=0.0.5)", "sphinx (>=2.0.0)", "sphinxcontrib-autoprogram (>=0.1.5)", "towncrier (>=18.5.0)"]
+testing = ["flaky (>=3.4.0)", "freezegun (>=0.3.11)", "pathlib2 (>=2.3.3)", "psutil (>=5.6.1)", "pytest (>=4.0.0)", "pytest-cov (>=2.5.1)", "pytest-mock (>=1.10.0)", "pytest-randomly (>=1.0.0)", "pytest-xdist (>=1.22.2)"]
 
 [[package]]
+name = "typing-extensions"
+version = "3.7.4.3"
+description = "Backported and Experimental Type Hints for Python 3.5+"
 category = "main"
-description = "HTTP library with thread-safe connection pooling, file post, and more."
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "urllib3"
+version = "1.26.2"
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
-version = "1.25.9"
 
 [package.extras]
 brotli = ["brotlipy (>=0.6.0)"]
-secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "pyOpenSSL (>=0.14)", "ipaddress"]
-socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7,<2.0)"]
+secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
+socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
-category = "dev"
-description = "Virtual Python Environment builder"
 name = "virtualenv"
+version = "20.2.1"
+description = "Virtual Python Environment builder"
+category = "dev"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
-version = "20.0.21"
 
 [package.dependencies]
 appdirs = ">=1.4.3,<2"
-distlib = ">=0.3.0,<1"
+distlib = ">=0.3.1,<1"
 filelock = ">=3.0.0,<4"
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
+importlib-resources = {version = ">=1.0", markers = "python_version < \"3.7\""}
 six = ">=1.9.0,<2"
 
-[package.dependencies.importlib-metadata]
-python = "<3.8"
-version = ">=0.12,<2"
-
-[package.dependencies.importlib-resources]
-python = "<3.7"
-version = ">=1.0,<2"
-
 [package.extras]
-docs = ["sphinx (>=3)", "sphinx-argparse (>=0.2.5)", "sphinx-rtd-theme (>=0.4.3)", "towncrier (>=19.9.0rc1)", "proselint (>=0.10.2)"]
-testing = ["pytest (>=4)", "coverage (>=5)", "coverage-enable-subprocess (>=1)", "pytest-xdist (>=1.31.0)", "pytest-mock (>=2)", "pytest-env (>=0.6.2)", "pytest-randomly (>=1)", "pytest-timeout", "packaging (>=20.0)", "xonsh (>=0.9.16)"]
+docs = ["proselint (>=0.10.2)", "sphinx (>=3)", "sphinx-argparse (>=0.2.5)", "sphinx-rtd-theme (>=0.4.3)", "towncrier (>=19.9.0rc1)"]
+testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", "pytest (>=4)", "pytest-env (>=0.6.2)", "pytest-freezegun (>=0.4.1)", "pytest-mock (>=2)", "pytest-randomly (>=1)", "pytest-timeout (>=1)", "pytest-xdist (>=1.31.0)", "packaging (>=20.0)", "xonsh (>=0.9.16)"]
 
 [[package]]
-category = "dev"
-description = "Measures the displayed width of unicode strings in a terminal"
 name = "wcwidth"
+version = "0.2.5"
+description = "Measures the displayed width of unicode strings in a terminal"
+category = "dev"
 optional = false
 python-versions = "*"
-version = "0.2.3"
 
 [[package]]
-category = "dev"
-description = "Backport of pathlib-compatible object wrapper for zip files"
-marker = "python_version < \"3.8\""
-name = "zipp"
+name = "yarl"
+version = "1.6.3"
+description = "Yet another URL library"
+category = "main"
 optional = false
 python-versions = ">=3.6"
-version = "3.1.0"
+
+[package.dependencies]
+idna = ">=2.0"
+multidict = ">=4.0"
+typing-extensions = {version = ">=3.7.4", markers = "python_version < \"3.8\""}
+
+[[package]]
+name = "zipp"
+version = "3.4.0"
+description = "Backport of pathlib-compatible object wrapper for zip files"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
-testing = ["jaraco.itertools", "func-timeout"]
+testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [metadata]
-content-hash = "03e62cff76df5899c1040111217e73bc3869b9b9fcd8d857bea962724a275f44"
-lock-version = "1.0"
+lock-version = "1.1"
 python-versions = "^3.6"
+content-hash = "014140ce3ee6ce4372ef82a713eba34a71edaedf85117793e0fb18d0e0ce072b"
 
 [metadata.files]
+aiohttp = [
+    {file = "aiohttp-3.7.3-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:328b552513d4f95b0a2eea4c8573e112866107227661834652a8984766aa7656"},
+    {file = "aiohttp-3.7.3-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:c733ef3bdcfe52a1a75564389bad4064352274036e7e234730526d155f04d914"},
+    {file = "aiohttp-3.7.3-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:2858b2504c8697beb9357be01dc47ef86438cc1cb36ecb6991796d19475faa3e"},
+    {file = "aiohttp-3.7.3-cp36-cp36m-manylinux2014_i686.whl", hash = "sha256:d2cfac21e31e841d60dc28c0ec7d4ec47a35c608cb8906435d47ef83ffb22150"},
+    {file = "aiohttp-3.7.3-cp36-cp36m-manylinux2014_ppc64le.whl", hash = "sha256:3228b7a51e3ed533f5472f54f70fd0b0a64c48dc1649a0f0e809bec312934d7a"},
+    {file = "aiohttp-3.7.3-cp36-cp36m-manylinux2014_s390x.whl", hash = "sha256:dcc119db14757b0c7bce64042158307b9b1c76471e655751a61b57f5a0e4d78e"},
+    {file = "aiohttp-3.7.3-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:7d9b42127a6c0bdcc25c3dcf252bb3ddc70454fac593b1b6933ae091396deb13"},
+    {file = "aiohttp-3.7.3-cp36-cp36m-win32.whl", hash = "sha256:df48a623c58180874d7407b4d9ec06a19b84ed47f60a3884345b1a5099c1818b"},
+    {file = "aiohttp-3.7.3-cp36-cp36m-win_amd64.whl", hash = "sha256:0b795072bb1bf87b8620120a6373a3c61bfcb8da7e5c2377f4bb23ff4f0b62c9"},
+    {file = "aiohttp-3.7.3-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:0d438c8ca703b1b714e82ed5b7a4412c82577040dadff479c08405e2a715564f"},
+    {file = "aiohttp-3.7.3-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:8389d6044ee4e2037dca83e3f6994738550f6ee8cfb746762283fad9b932868f"},
+    {file = "aiohttp-3.7.3-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:3ea8c252d8df5e9166bcf3d9edced2af132f4ead8ac422eac723c5781063709a"},
+    {file = "aiohttp-3.7.3-cp37-cp37m-manylinux2014_i686.whl", hash = "sha256:78e2f18a82b88cbc37d22365cf8d2b879a492faedb3f2975adb4ed8dfe994d3a"},
+    {file = "aiohttp-3.7.3-cp37-cp37m-manylinux2014_ppc64le.whl", hash = "sha256:df3a7b258cc230a65245167a202dd07320a5af05f3d41da1488ba0fa05bc9347"},
+    {file = "aiohttp-3.7.3-cp37-cp37m-manylinux2014_s390x.whl", hash = "sha256:f326b3c1bbfda5b9308252ee0dcb30b612ee92b0e105d4abec70335fab5b1245"},
+    {file = "aiohttp-3.7.3-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:5e479df4b2d0f8f02133b7e4430098699450e1b2a826438af6bec9a400530957"},
+    {file = "aiohttp-3.7.3-cp37-cp37m-win32.whl", hash = "sha256:6d42debaf55450643146fabe4b6817bb2a55b23698b0434107e892a43117285e"},
+    {file = "aiohttp-3.7.3-cp37-cp37m-win_amd64.whl", hash = "sha256:c9c58b0b84055d8bc27b7df5a9d141df4ee6ff59821f922dd73155861282f6a3"},
+    {file = "aiohttp-3.7.3-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:f411cb22115cb15452d099fec0ee636b06cf81bfb40ed9c02d30c8dc2bc2e3d1"},
+    {file = "aiohttp-3.7.3-cp38-cp38-manylinux1_i686.whl", hash = "sha256:c1e0920909d916d3375c7a1fdb0b1c78e46170e8bb42792312b6eb6676b2f87f"},
+    {file = "aiohttp-3.7.3-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:59d11674964b74a81b149d4ceaff2b674b3b0e4d0f10f0be1533e49c4a28408b"},
+    {file = "aiohttp-3.7.3-cp38-cp38-manylinux2014_i686.whl", hash = "sha256:41608c0acbe0899c852281978492f9ce2c6fbfaf60aff0cefc54a7c4516b822c"},
+    {file = "aiohttp-3.7.3-cp38-cp38-manylinux2014_ppc64le.whl", hash = "sha256:16a3cb5df5c56f696234ea9e65e227d1ebe9c18aa774d36ff42f532139066a5f"},
+    {file = "aiohttp-3.7.3-cp38-cp38-manylinux2014_s390x.whl", hash = "sha256:6ccc43d68b81c424e46192a778f97da94ee0630337c9bbe5b2ecc9b0c1c59001"},
+    {file = "aiohttp-3.7.3-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:d03abec50df423b026a5aa09656bd9d37f1e6a49271f123f31f9b8aed5dc3ea3"},
+    {file = "aiohttp-3.7.3-cp38-cp38-win32.whl", hash = "sha256:39f4b0a6ae22a1c567cb0630c30dd082481f95c13ca528dc501a7766b9c718c0"},
+    {file = "aiohttp-3.7.3-cp38-cp38-win_amd64.whl", hash = "sha256:c68fdf21c6f3573ae19c7ee65f9ff185649a060c9a06535e9c3a0ee0bbac9235"},
+    {file = "aiohttp-3.7.3-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:710376bf67d8ff4500a31d0c207b8941ff4fba5de6890a701d71680474fe2a60"},
+    {file = "aiohttp-3.7.3-cp39-cp39-manylinux1_i686.whl", hash = "sha256:2406dc1dda01c7f6060ab586e4601f18affb7a6b965c50a8c90ff07569cf782a"},
+    {file = "aiohttp-3.7.3-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:2a7b7640167ab536c3cb90cfc3977c7094f1c5890d7eeede8b273c175c3910fd"},
+    {file = "aiohttp-3.7.3-cp39-cp39-manylinux2014_i686.whl", hash = "sha256:684850fb1e3e55c9220aad007f8386d8e3e477c4ec9211ae54d968ecdca8c6f9"},
+    {file = "aiohttp-3.7.3-cp39-cp39-manylinux2014_ppc64le.whl", hash = "sha256:1edfd82a98c5161497bbb111b2b70c0813102ad7e0aa81cbeb34e64c93863005"},
+    {file = "aiohttp-3.7.3-cp39-cp39-manylinux2014_s390x.whl", hash = "sha256:77149002d9386fae303a4a162e6bce75cc2161347ad2ba06c2f0182561875d45"},
+    {file = "aiohttp-3.7.3-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:756ae7efddd68d4ea7d89c636b703e14a0c686688d42f588b90778a3c2fc0564"},
+    {file = "aiohttp-3.7.3-cp39-cp39-win32.whl", hash = "sha256:3b0036c978cbcc4a4512278e98e3e6d9e6b834dc973206162eddf98b586ef1c6"},
+    {file = "aiohttp-3.7.3-cp39-cp39-win_amd64.whl", hash = "sha256:e1b95972a0ae3f248a899cdbac92ba2e01d731225f566569311043ce2226f5e7"},
+    {file = "aiohttp-3.7.3.tar.gz", hash = "sha256:9c1a81af067e72261c9cbe33ea792893e83bc6aa987bfbd6fdc1e5e7b22777c4"},
+]
 appdirs = [
     {file = "appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"},
     {file = "appdirs-1.4.4.tar.gz", hash = "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41"},
+]
+async-timeout = [
+    {file = "async-timeout-3.0.1.tar.gz", hash = "sha256:0c3c816a028d47f659d6ff5c745cb2acf1f966da1fe5c19c77a70282b25f4c5f"},
+    {file = "async_timeout-3.0.1-py3-none-any.whl", hash = "sha256:4291ca197d287d274d0b6cb5d6f8f8f82d434ed288f962539ff18cc9012f9ea3"},
 ]
 atomicwrites = [
     {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
     {file = "atomicwrites-1.4.0.tar.gz", hash = "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"},
 ]
 attrs = [
-    {file = "attrs-19.3.0-py2.py3-none-any.whl", hash = "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c"},
-    {file = "attrs-19.3.0.tar.gz", hash = "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"},
+    {file = "attrs-20.3.0-py2.py3-none-any.whl", hash = "sha256:31b2eced602aa8423c2aea9c76a724617ed67cf9513173fd3a4f03e3a929c7e6"},
+    {file = "attrs-20.3.0.tar.gz", hash = "sha256:832aa3cde19744e49938b91fea06d69ecb9e649c93ba974535d08ad92164f700"},
 ]
 certifi = [
-    {file = "certifi-2020.4.5.1-py2.py3-none-any.whl", hash = "sha256:1d987a998c75633c40847cc966fcf5904906c920a7f17ef374f5aa4282abd304"},
-    {file = "certifi-2020.4.5.1.tar.gz", hash = "sha256:51fcb31174be6e6664c5f69e3e1691a2d72a1a12e90f872cbdb1567eb47b6519"},
+    {file = "certifi-2020.11.8-py2.py3-none-any.whl", hash = "sha256:1f422849db327d534e3d0c5f02a263458c3955ec0aae4ff09b95f195c59f4edd"},
+    {file = "certifi-2020.11.8.tar.gz", hash = "sha256:f05def092c44fbf25834a51509ef6e631dc19765ab8a57b4e7ab85531f0a9cf4"},
 ]
 chardet = [
     {file = "chardet-3.0.4-py2.py3-none-any.whl", hash = "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"},
     {file = "chardet-3.0.4.tar.gz", hash = "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae"},
 ]
 colorama = [
-    {file = "colorama-0.4.3-py2.py3-none-any.whl", hash = "sha256:7d73d2a99753107a36ac6b455ee49046802e59d9d076ef8e47b61499fa29afff"},
-    {file = "colorama-0.4.3.tar.gz", hash = "sha256:e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1"},
+    {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
+    {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
 coverage = [
-    {file = "coverage-5.1-cp27-cp27m-macosx_10_12_x86_64.whl", hash = "sha256:0cb4be7e784dcdc050fc58ef05b71aa8e89b7e6636b99967fadbdba694cf2b65"},
-    {file = "coverage-5.1-cp27-cp27m-macosx_10_13_intel.whl", hash = "sha256:c317eaf5ff46a34305b202e73404f55f7389ef834b8dbf4da09b9b9b37f76dd2"},
-    {file = "coverage-5.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:b83835506dfc185a319031cf853fa4bb1b3974b1f913f5bb1a0f3d98bdcded04"},
-    {file = "coverage-5.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:5f2294dbf7875b991c381e3d5af2bcc3494d836affa52b809c91697449d0eda6"},
-    {file = "coverage-5.1-cp27-cp27m-win32.whl", hash = "sha256:de807ae933cfb7f0c7d9d981a053772452217df2bf38e7e6267c9cbf9545a796"},
-    {file = "coverage-5.1-cp27-cp27m-win_amd64.whl", hash = "sha256:bf9cb9a9fd8891e7efd2d44deb24b86d647394b9705b744ff6f8261e6f29a730"},
-    {file = "coverage-5.1-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:acf3763ed01af8410fc36afea23707d4ea58ba7e86a8ee915dfb9ceff9ef69d0"},
-    {file = "coverage-5.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:dec5202bfe6f672d4511086e125db035a52b00f1648d6407cc8e526912c0353a"},
-    {file = "coverage-5.1-cp35-cp35m-macosx_10_12_x86_64.whl", hash = "sha256:7a5bdad4edec57b5fb8dae7d3ee58622d626fd3a0be0dfceda162a7035885ecf"},
-    {file = "coverage-5.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:1601e480b9b99697a570cea7ef749e88123c04b92d84cedaa01e117436b4a0a9"},
-    {file = "coverage-5.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:dbe8c6ae7534b5b024296464f387d57c13caa942f6d8e6e0346f27e509f0f768"},
-    {file = "coverage-5.1-cp35-cp35m-win32.whl", hash = "sha256:a027ef0492ede1e03a8054e3c37b8def89a1e3c471482e9f046906ba4f2aafd2"},
-    {file = "coverage-5.1-cp35-cp35m-win_amd64.whl", hash = "sha256:0e61d9803d5851849c24f78227939c701ced6704f337cad0a91e0972c51c1ee7"},
-    {file = "coverage-5.1-cp36-cp36m-macosx_10_13_x86_64.whl", hash = "sha256:2d27a3f742c98e5c6b461ee6ef7287400a1956c11421eb574d843d9ec1f772f0"},
-    {file = "coverage-5.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:66460ab1599d3cf894bb6baee8c684788819b71a5dc1e8fa2ecc152e5d752019"},
-    {file = "coverage-5.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:5c542d1e62eece33c306d66fe0a5c4f7f7b3c08fecc46ead86d7916684b36d6c"},
-    {file = "coverage-5.1-cp36-cp36m-win32.whl", hash = "sha256:2742c7515b9eb368718cd091bad1a1b44135cc72468c731302b3d641895b83d1"},
-    {file = "coverage-5.1-cp36-cp36m-win_amd64.whl", hash = "sha256:dead2ddede4c7ba6cb3a721870f5141c97dc7d85a079edb4bd8d88c3ad5b20c7"},
-    {file = "coverage-5.1-cp37-cp37m-macosx_10_13_x86_64.whl", hash = "sha256:01333e1bd22c59713ba8a79f088b3955946e293114479bbfc2e37d522be03355"},
-    {file = "coverage-5.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:e1ea316102ea1e1770724db01998d1603ed921c54a86a2efcb03428d5417e489"},
-    {file = "coverage-5.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:adeb4c5b608574a3d647011af36f7586811a2c1197c861aedb548dd2453b41cd"},
-    {file = "coverage-5.1-cp37-cp37m-win32.whl", hash = "sha256:782caea581a6e9ff75eccda79287daefd1d2631cc09d642b6ee2d6da21fc0a4e"},
-    {file = "coverage-5.1-cp37-cp37m-win_amd64.whl", hash = "sha256:00f1d23f4336efc3b311ed0d807feb45098fc86dee1ca13b3d6768cdab187c8a"},
-    {file = "coverage-5.1-cp38-cp38-macosx_10_13_x86_64.whl", hash = "sha256:402e1744733df483b93abbf209283898e9f0d67470707e3c7516d84f48524f55"},
-    {file = "coverage-5.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:a3f3654d5734a3ece152636aad89f58afc9213c6520062db3978239db122f03c"},
-    {file = "coverage-5.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:6402bd2fdedabbdb63a316308142597534ea8e1895f4e7d8bf7476c5e8751fef"},
-    {file = "coverage-5.1-cp38-cp38-win32.whl", hash = "sha256:8fa0cbc7ecad630e5b0f4f35b0f6ad419246b02bc750de7ac66db92667996d24"},
-    {file = "coverage-5.1-cp38-cp38-win_amd64.whl", hash = "sha256:79a3cfd6346ce6c13145731d39db47b7a7b859c0272f02cdb89a3bdcbae233a0"},
-    {file = "coverage-5.1-cp39-cp39-win32.whl", hash = "sha256:a82b92b04a23d3c8a581fc049228bafde988abacba397d57ce95fe95e0338ab4"},
-    {file = "coverage-5.1-cp39-cp39-win_amd64.whl", hash = "sha256:bb28a7245de68bf29f6fb199545d072d1036a1917dca17a1e75bbb919e14ee8e"},
-    {file = "coverage-5.1.tar.gz", hash = "sha256:f90bfc4ad18450c80b024036eaf91e4a246ae287701aaa88eaebebf150868052"},
+    {file = "coverage-5.3-cp27-cp27m-macosx_10_13_intel.whl", hash = "sha256:bd3166bb3b111e76a4f8e2980fa1addf2920a4ca9b2b8ca36a3bc3dedc618270"},
+    {file = "coverage-5.3-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:9342dd70a1e151684727c9c91ea003b2fb33523bf19385d4554f7897ca0141d4"},
+    {file = "coverage-5.3-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:63808c30b41f3bbf65e29f7280bf793c79f54fb807057de7e5238ffc7cc4d7b9"},
+    {file = "coverage-5.3-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:4d6a42744139a7fa5b46a264874a781e8694bb32f1d76d8137b68138686f1729"},
+    {file = "coverage-5.3-cp27-cp27m-win32.whl", hash = "sha256:86e9f8cd4b0cdd57b4ae71a9c186717daa4c5a99f3238a8723f416256e0b064d"},
+    {file = "coverage-5.3-cp27-cp27m-win_amd64.whl", hash = "sha256:7858847f2d84bf6e64c7f66498e851c54de8ea06a6f96a32a1d192d846734418"},
+    {file = "coverage-5.3-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:530cc8aaf11cc2ac7430f3614b04645662ef20c348dce4167c22d99bec3480e9"},
+    {file = "coverage-5.3-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:381ead10b9b9af5f64646cd27107fb27b614ee7040bb1226f9c07ba96625cbb5"},
+    {file = "coverage-5.3-cp35-cp35m-macosx_10_13_x86_64.whl", hash = "sha256:71b69bd716698fa62cd97137d6f2fdf49f534decb23a2c6fc80813e8b7be6822"},
+    {file = "coverage-5.3-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:1d44bb3a652fed01f1f2c10d5477956116e9b391320c94d36c6bf13b088a1097"},
+    {file = "coverage-5.3-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:1c6703094c81fa55b816f5ae542c6ffc625fec769f22b053adb42ad712d086c9"},
+    {file = "coverage-5.3-cp35-cp35m-win32.whl", hash = "sha256:cedb2f9e1f990918ea061f28a0f0077a07702e3819602d3507e2ff98c8d20636"},
+    {file = "coverage-5.3-cp35-cp35m-win_amd64.whl", hash = "sha256:7f43286f13d91a34fadf61ae252a51a130223c52bfefb50310d5b2deb062cf0f"},
+    {file = "coverage-5.3-cp36-cp36m-macosx_10_13_x86_64.whl", hash = "sha256:c851b35fc078389bc16b915a0a7c1d5923e12e2c5aeec58c52f4aa8085ac8237"},
+    {file = "coverage-5.3-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:aac1ba0a253e17889550ddb1b60a2063f7474155465577caa2a3b131224cfd54"},
+    {file = "coverage-5.3-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:2b31f46bf7b31e6aa690d4c7a3d51bb262438c6dcb0d528adde446531d0d3bb7"},
+    {file = "coverage-5.3-cp36-cp36m-win32.whl", hash = "sha256:c5f17ad25d2c1286436761b462e22b5020d83316f8e8fcb5deb2b3151f8f1d3a"},
+    {file = "coverage-5.3-cp36-cp36m-win_amd64.whl", hash = "sha256:aef72eae10b5e3116bac6957de1df4d75909fc76d1499a53fb6387434b6bcd8d"},
+    {file = "coverage-5.3-cp37-cp37m-macosx_10_13_x86_64.whl", hash = "sha256:e8caf961e1b1a945db76f1b5fa9c91498d15f545ac0ababbe575cfab185d3bd8"},
+    {file = "coverage-5.3-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:29a6272fec10623fcbe158fdf9abc7a5fa032048ac1d8631f14b50fbfc10d17f"},
+    {file = "coverage-5.3-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:2d43af2be93ffbad25dd959899b5b809618a496926146ce98ee0b23683f8c51c"},
+    {file = "coverage-5.3-cp37-cp37m-win32.whl", hash = "sha256:c3888a051226e676e383de03bf49eb633cd39fc829516e5334e69b8d81aae751"},
+    {file = "coverage-5.3-cp37-cp37m-win_amd64.whl", hash = "sha256:9669179786254a2e7e57f0ecf224e978471491d660aaca833f845b72a2df3709"},
+    {file = "coverage-5.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:0203acd33d2298e19b57451ebb0bed0ab0c602e5cf5a818591b4918b1f97d516"},
+    {file = "coverage-5.3-cp38-cp38-manylinux1_i686.whl", hash = "sha256:582ddfbe712025448206a5bc45855d16c2e491c2dd102ee9a2841418ac1c629f"},
+    {file = "coverage-5.3-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:0f313707cdecd5cd3e217fc68c78a960b616604b559e9ea60cc16795c4304259"},
+    {file = "coverage-5.3-cp38-cp38-win32.whl", hash = "sha256:78e93cc3571fd928a39c0b26767c986188a4118edc67bc0695bc7a284da22e82"},
+    {file = "coverage-5.3-cp38-cp38-win_amd64.whl", hash = "sha256:8f264ba2701b8c9f815b272ad568d555ef98dfe1576802ab3149c3629a9f2221"},
+    {file = "coverage-5.3-cp39-cp39-macosx_10_13_x86_64.whl", hash = "sha256:50691e744714856f03a86df3e2bff847c2acede4c191f9a1da38f088df342978"},
+    {file = "coverage-5.3-cp39-cp39-manylinux1_i686.whl", hash = "sha256:9361de40701666b034c59ad9e317bae95c973b9ff92513dd0eced11c6adf2e21"},
+    {file = "coverage-5.3-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:c1b78fb9700fc961f53386ad2fd86d87091e06ede5d118b8a50dea285a071c24"},
+    {file = "coverage-5.3-cp39-cp39-win32.whl", hash = "sha256:cb7df71de0af56000115eafd000b867d1261f786b5eebd88a0ca6360cccfaca7"},
+    {file = "coverage-5.3-cp39-cp39-win_amd64.whl", hash = "sha256:47a11bdbd8ada9b7ee628596f9d97fbd3851bd9999d398e9436bd67376dbece7"},
+    {file = "coverage-5.3.tar.gz", hash = "sha256:280baa8ec489c4f542f8940f9c4c2181f0306a8ee1a54eceba071a449fb870a0"},
 ]
 distlib = [
-    {file = "distlib-0.3.0.zip", hash = "sha256:2e166e231a26b36d6dfe35a48c4464346620f8645ed0ace01ee31822b288de21"},
+    {file = "distlib-0.3.1-py2.py3-none-any.whl", hash = "sha256:8c09de2c67b3e7deef7184574fc060ab8a793e7adbb183d942c389c8b13c52fb"},
+    {file = "distlib-0.3.1.zip", hash = "sha256:edf6116872c863e1aa9d5bb7cb5e05a022c519a4594dc703843343a9ddd9bff1"},
 ]
 filelock = [
     {file = "filelock-3.0.12-py3-none-any.whl", hash = "sha256:929b7d63ec5b7d6b71b0fa5ac14e030b3f70b75747cef1b10da9b879fef15836"},
     {file = "filelock-3.0.12.tar.gz", hash = "sha256:18d82244ee114f543149c66a6e0c14e9c4f8a1044b5cdaadd0f82159d6a6ff59"},
 ]
 flake8 = [
-    {file = "flake8-3.8.2-py2.py3-none-any.whl", hash = "sha256:ccaa799ef9893cebe69fdfefed76865aeaefbb94cb8545617b2298786a4de9a5"},
-    {file = "flake8-3.8.2.tar.gz", hash = "sha256:c69ac1668e434d37a2d2880b3ca9aafd54b3a10a3ac1ab101d22f29e29cf8634"},
+    {file = "flake8-3.8.4-py2.py3-none-any.whl", hash = "sha256:749dbbd6bfd0cf1318af27bf97a14e28e5ff548ef8e5b1566ccfb25a11e7c839"},
+    {file = "flake8-3.8.4.tar.gz", hash = "sha256:aadae8761ec651813c24be05c6f7b4680857ef6afaae4651a4eccaef97ce6c3b"},
 ]
 idna = [
-    {file = "idna-2.9-py2.py3-none-any.whl", hash = "sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa"},
-    {file = "idna-2.9.tar.gz", hash = "sha256:7588d1c14ae4c77d74036e8c22ff447b26d0fde8f007354fd48a7814db15b7cb"},
+    {file = "idna-2.10-py2.py3-none-any.whl", hash = "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"},
+    {file = "idna-2.10.tar.gz", hash = "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6"},
+]
+idna-ssl = [
+    {file = "idna-ssl-1.1.0.tar.gz", hash = "sha256:a933e3bb13da54383f9e8f35dc4f9cb9eb9b3b78c6b36f311254d6d0d92c6c7c"},
 ]
 ifaddr = [
     {file = "ifaddr-0.1.7-py2.py3-none-any.whl", hash = "sha256:d1f603952f0a71c9ab4e705754511e4e03b02565bc4cec7188ad6415ff534cd3"},
     {file = "ifaddr-0.1.7.tar.gz", hash = "sha256:1f9e8a6ca6f16db5a37d3356f07b6e52344f6f9f7e806d618537731669eb1a94"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-1.6.0-py2.py3-none-any.whl", hash = "sha256:2a688cbaa90e0cc587f1df48bdc97a6eadccdcd9c35fb3f976a09e3b5016d90f"},
-    {file = "importlib_metadata-1.6.0.tar.gz", hash = "sha256:34513a8a0c4962bc66d35b359558fd8a5e10cd472d37aec5f66858addef32c1e"},
+    {file = "importlib_metadata-2.1.1-py2.py3-none-any.whl", hash = "sha256:c2d6341ff566f609e89a2acb2db190e5e1d23d5409d6cc8d2fe34d72443876d4"},
+    {file = "importlib_metadata-2.1.1.tar.gz", hash = "sha256:b8de9eff2b35fb037368f28a7df1df4e6436f578fa74423505b6c6a778d5b5dd"},
 ]
 importlib-resources = [
-    {file = "importlib_resources-1.5.0-py2.py3-none-any.whl", hash = "sha256:85dc0b9b325ff78c8bef2e4ff42616094e16b98ebd5e3b50fe7e2f0bbcdcde49"},
-    {file = "importlib_resources-1.5.0.tar.gz", hash = "sha256:6f87df66833e1942667108628ec48900e02a4ab4ad850e25fbf07cb17cf734ca"},
+    {file = "importlib_resources-3.3.0-py2.py3-none-any.whl", hash = "sha256:a3d34a8464ce1d5d7c92b0ea4e921e696d86f2aa212e684451cb1482c8d84ed5"},
+    {file = "importlib_resources-3.3.0.tar.gz", hash = "sha256:7b51f0106c8ec564b1bef3d9c588bc694ce2b92125bbb6278f4f2f5b54ec3592"},
 ]
 lxml = [
-    {file = "lxml-4.5.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:ee2be8b8f72a2772e72ab926a3bccebf47bb727bda41ae070dc91d1fb759b726"},
-    {file = "lxml-4.5.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:fadd2a63a2bfd7fb604508e553d1cf68eca250b2fbdbd81213b5f6f2fbf23529"},
-    {file = "lxml-4.5.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:4f282737d187ae723b2633856085c31ae5d4d432968b7f3f478a48a54835f5c4"},
-    {file = "lxml-4.5.1-cp27-cp27m-win32.whl", hash = "sha256:7fd88cb91a470b383aafad554c3fe1ccf6dfb2456ff0e84b95335d582a799804"},
-    {file = "lxml-4.5.1-cp27-cp27m-win_amd64.whl", hash = "sha256:0790ddca3f825dd914978c94c2545dbea5f56f008b050e835403714babe62a5f"},
-    {file = "lxml-4.5.1-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:9144ce36ca0824b29ebc2e02ca186e54040ebb224292072250467190fb613b96"},
-    {file = "lxml-4.5.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:a636346c6c0e1092ffc202d97ec1843a75937d8c98aaf6771348ad6422e44bb0"},
-    {file = "lxml-4.5.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:f95d28193c3863132b1f55c1056036bf580b5a488d908f7d22a04ace8935a3a9"},
-    {file = "lxml-4.5.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:b26719890c79a1dae7d53acac5f089d66fd8cc68a81f4e4bd355e45470dc25e1"},
-    {file = "lxml-4.5.1-cp35-cp35m-win32.whl", hash = "sha256:a9e3b8011388e7e373565daa5e92f6c9cb844790dc18e43073212bb3e76f7007"},
-    {file = "lxml-4.5.1-cp35-cp35m-win_amd64.whl", hash = "sha256:2754d4406438c83144f9ffd3628bbe2dcc6d62b20dbc5c1ec4bc4385e5d44b42"},
-    {file = "lxml-4.5.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:925baf6ff1ef2c45169f548cc85204433e061360bfa7d01e1be7ae38bef73194"},
-    {file = "lxml-4.5.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:a87dbee7ad9dce3aaefada2081843caf08a44a8f52e03e0a4cc5819f8398f2f4"},
-    {file = "lxml-4.5.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:51bb4edeb36d24ec97eb3e6a6007be128b720114f9a875d6b370317d62ac80b9"},
-    {file = "lxml-4.5.1-cp36-cp36m-win32.whl", hash = "sha256:c79e5debbe092e3c93ca4aee44c9a7631bdd407b2871cb541b979fd350bbbc29"},
-    {file = "lxml-4.5.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b7462cdab6fffcda853338e1741ce99706cdf880d921b5a769202ea7b94e8528"},
-    {file = "lxml-4.5.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:06748c7192eab0f48e3d35a7adae609a329c6257495d5e53878003660dc0fec6"},
-    {file = "lxml-4.5.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:1aa7a6197c1cdd65d974f3e4953764eee3d9c7b67e3966616b41fab7f8f516b7"},
-    {file = "lxml-4.5.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:afb53edf1046599991fb4a7d03e601ab5f5422a5435c47ee6ba91ec3b61416a6"},
-    {file = "lxml-4.5.1-cp37-cp37m-win32.whl", hash = "sha256:2d1ddce96cf15f1254a68dba6935e6e0f1fe39247de631c115e84dd404a6f031"},
-    {file = "lxml-4.5.1-cp37-cp37m-win_amd64.whl", hash = "sha256:22c6d34fdb0e65d5f782a4d1a1edb52e0a8365858dafb1c08cb1d16546cf0786"},
-    {file = "lxml-4.5.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:c47a8a5d00060122ca5908909478abce7bbf62d812e3fc35c6c802df8fb01fe7"},
-    {file = "lxml-4.5.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:b77975465234ff49fdad871c08aa747aae06f5e5be62866595057c43f8d2f62c"},
-    {file = "lxml-4.5.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:2b02c106709466a93ed424454ce4c970791c486d5fcdf52b0d822a7e29789626"},
-    {file = "lxml-4.5.1-cp38-cp38-win32.whl", hash = "sha256:7eee37c1b9815e6505847aa5e68f192e8a1b730c5c7ead39ff317fde9ce29448"},
-    {file = "lxml-4.5.1-cp38-cp38-win_amd64.whl", hash = "sha256:d8d40e0121ca1606aa9e78c28a3a7d88a05c06b3ca61630242cded87d8ce55fa"},
-    {file = "lxml-4.5.1.tar.gz", hash = "sha256:27ee0faf8077c7c1a589573b1450743011117f1aa1a91d5ae776bbc5ca6070f2"},
+    {file = "lxml-4.6.2-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:a9d6bc8642e2c67db33f1247a77c53476f3a166e09067c0474facb045756087f"},
+    {file = "lxml-4.6.2-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:791394449e98243839fa822a637177dd42a95f4883ad3dec2a0ce6ac99fb0a9d"},
+    {file = "lxml-4.6.2-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:68a5d77e440df94011214b7db907ec8f19e439507a70c958f750c18d88f995d2"},
+    {file = "lxml-4.6.2-cp27-cp27m-win32.whl", hash = "sha256:fc37870d6716b137e80d19241d0e2cff7a7643b925dfa49b4c8ebd1295eb506e"},
+    {file = "lxml-4.6.2-cp27-cp27m-win_amd64.whl", hash = "sha256:69a63f83e88138ab7642d8f61418cf3180a4d8cd13995df87725cb8b893e950e"},
+    {file = "lxml-4.6.2-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:42ebca24ba2a21065fb546f3e6bd0c58c3fe9ac298f3a320147029a4850f51a2"},
+    {file = "lxml-4.6.2-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:f83d281bb2a6217cd806f4cf0ddded436790e66f393e124dfe9731f6b3fb9afe"},
+    {file = "lxml-4.6.2-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:535f067002b0fd1a4e5296a8f1bf88193080ff992a195e66964ef2a6cfec5388"},
+    {file = "lxml-4.6.2-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:366cb750140f221523fa062d641393092813b81e15d0e25d9f7c6025f910ee80"},
+    {file = "lxml-4.6.2-cp35-cp35m-manylinux2014_aarch64.whl", hash = "sha256:97db258793d193c7b62d4e2586c6ed98d51086e93f9a3af2b2034af01450a74b"},
+    {file = "lxml-4.6.2-cp35-cp35m-win32.whl", hash = "sha256:648914abafe67f11be7d93c1a546068f8eff3c5fa938e1f94509e4a5d682b2d8"},
+    {file = "lxml-4.6.2-cp35-cp35m-win_amd64.whl", hash = "sha256:4e751e77006da34643ab782e4a5cc21ea7b755551db202bc4d3a423b307db780"},
+    {file = "lxml-4.6.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:681d75e1a38a69f1e64ab82fe4b1ed3fd758717bed735fb9aeaa124143f051af"},
+    {file = "lxml-4.6.2-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:127f76864468d6630e1b453d3ffbbd04b024c674f55cf0a30dc2595137892d37"},
+    {file = "lxml-4.6.2-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:4fb85c447e288df535b17ebdebf0ec1cf3a3f1a8eba7e79169f4f37af43c6b98"},
+    {file = "lxml-4.6.2-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:5be4a2e212bb6aa045e37f7d48e3e1e4b6fd259882ed5a00786f82e8c37ce77d"},
+    {file = "lxml-4.6.2-cp36-cp36m-win32.whl", hash = "sha256:8c88b599e226994ad4db29d93bc149aa1aff3dc3a4355dd5757569ba78632bdf"},
+    {file = "lxml-4.6.2-cp36-cp36m-win_amd64.whl", hash = "sha256:6e4183800f16f3679076dfa8abf2db3083919d7e30764a069fb66b2b9eff9939"},
+    {file = "lxml-4.6.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:d8d3d4713f0c28bdc6c806a278d998546e8efc3498949e3ace6e117462ac0a5e"},
+    {file = "lxml-4.6.2-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:8246f30ca34dc712ab07e51dc34fea883c00b7ccb0e614651e49da2c49a30711"},
+    {file = "lxml-4.6.2-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:923963e989ffbceaa210ac37afc9b906acebe945d2723e9679b643513837b089"},
+    {file = "lxml-4.6.2-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:1471cee35eba321827d7d53d104e7b8c593ea3ad376aa2df89533ce8e1b24a01"},
+    {file = "lxml-4.6.2-cp37-cp37m-win32.whl", hash = "sha256:2363c35637d2d9d6f26f60a208819e7eafc4305ce39dc1d5005eccc4593331c2"},
+    {file = "lxml-4.6.2-cp37-cp37m-win_amd64.whl", hash = "sha256:f4822c0660c3754f1a41a655e37cb4dbbc9be3d35b125a37fab6f82d47674ebc"},
+    {file = "lxml-4.6.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:0448576c148c129594d890265b1a83b9cd76fd1f0a6a04620753d9a6bcfd0a4d"},
+    {file = "lxml-4.6.2-cp38-cp38-manylinux1_i686.whl", hash = "sha256:60a20bfc3bd234d54d49c388950195d23a5583d4108e1a1d47c9eef8d8c042b3"},
+    {file = "lxml-4.6.2-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:2e5cc908fe43fe1aa299e58046ad66981131a66aea3129aac7770c37f590a644"},
+    {file = "lxml-4.6.2-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:50c348995b47b5a4e330362cf39fc503b4a43b14a91c34c83b955e1805c8e308"},
+    {file = "lxml-4.6.2-cp38-cp38-win32.whl", hash = "sha256:94d55bd03d8671686e3f012577d9caa5421a07286dd351dfef64791cf7c6c505"},
+    {file = "lxml-4.6.2-cp38-cp38-win_amd64.whl", hash = "sha256:7a7669ff50f41225ca5d6ee0a1ec8413f3a0d8aa2b109f86d540887b7ec0d72a"},
+    {file = "lxml-4.6.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:e0bfe9bb028974a481410432dbe1b182e8191d5d40382e5b8ff39cdd2e5c5931"},
+    {file = "lxml-4.6.2-cp39-cp39-manylinux1_i686.whl", hash = "sha256:6fd8d5903c2e53f49e99359b063df27fdf7acb89a52b6a12494208bf61345a03"},
+    {file = "lxml-4.6.2-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:7e9eac1e526386df7c70ef253b792a0a12dd86d833b1d329e038c7a235dfceb5"},
+    {file = "lxml-4.6.2-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:7ee8af0b9f7de635c61cdd5b8534b76c52cd03536f29f51151b377f76e214a1a"},
+    {file = "lxml-4.6.2-cp39-cp39-win32.whl", hash = "sha256:2e6fd1b8acd005bd71e6c94f30c055594bbd0aa02ef51a22bbfa961ab63b2d75"},
+    {file = "lxml-4.6.2-cp39-cp39-win_amd64.whl", hash = "sha256:535332fe9d00c3cd455bd3dd7d4bacab86e2d564bdf7606079160fa6251caacf"},
+    {file = "lxml-4.6.2.tar.gz", hash = "sha256:cd11c7e8d21af997ee8079037fff88f16fda188a9776eb4b81c7e4c9c0a7d7fc"},
 ]
 mccabe = [
     {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
@@ -554,20 +653,59 @@ mock = [
     {file = "mock-4.0.2.tar.gz", hash = "sha256:dd33eb70232b6118298d516bbcecd26704689c386594f0f3c4f13867b2c56f72"},
 ]
 more-itertools = [
-    {file = "more-itertools-8.3.0.tar.gz", hash = "sha256:558bb897a2232f5e4f8e2399089e35aecb746e1f9191b6584a151647e89267be"},
-    {file = "more_itertools-8.3.0-py3-none-any.whl", hash = "sha256:7818f596b1e87be009031c7653d01acc46ed422e6656b394b0f765ce66ed4982"},
+    {file = "more-itertools-8.6.0.tar.gz", hash = "sha256:b3a9005928e5bed54076e6e549c792b306fddfe72b2d1d22dd63d42d5d3899cf"},
+    {file = "more_itertools-8.6.0-py3-none-any.whl", hash = "sha256:8e1a2a43b2f2727425f2b5839587ae37093f19153dc26c0927d1048ff6557330"},
+]
+multidict = [
+    {file = "multidict-5.1.0-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:b7993704f1a4b204e71debe6095150d43b2ee6150fa4f44d6d966ec356a8d61f"},
+    {file = "multidict-5.1.0-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:9dd6e9b1a913d096ac95d0399bd737e00f2af1e1594a787e00f7975778c8b2bf"},
+    {file = "multidict-5.1.0-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:f21756997ad8ef815d8ef3d34edd98804ab5ea337feedcd62fb52d22bf531281"},
+    {file = "multidict-5.1.0-cp36-cp36m-manylinux2014_i686.whl", hash = "sha256:1ab820665e67373de5802acae069a6a05567ae234ddb129f31d290fc3d1aa56d"},
+    {file = "multidict-5.1.0-cp36-cp36m-manylinux2014_ppc64le.whl", hash = "sha256:9436dc58c123f07b230383083855593550c4d301d2532045a17ccf6eca505f6d"},
+    {file = "multidict-5.1.0-cp36-cp36m-manylinux2014_s390x.whl", hash = "sha256:830f57206cc96ed0ccf68304141fec9481a096c4d2e2831f311bde1c404401da"},
+    {file = "multidict-5.1.0-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:2e68965192c4ea61fff1b81c14ff712fc7dc15d2bd120602e4a3494ea6584224"},
+    {file = "multidict-5.1.0-cp36-cp36m-win32.whl", hash = "sha256:2f1a132f1c88724674271d636e6b7351477c27722f2ed789f719f9e3545a3d26"},
+    {file = "multidict-5.1.0-cp36-cp36m-win_amd64.whl", hash = "sha256:3a4f32116f8f72ecf2a29dabfb27b23ab7cdc0ba807e8459e59a93a9be9506f6"},
+    {file = "multidict-5.1.0-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:46c73e09ad374a6d876c599f2328161bcd95e280f84d2060cf57991dec5cfe76"},
+    {file = "multidict-5.1.0-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:018132dbd8688c7a69ad89c4a3f39ea2f9f33302ebe567a879da8f4ca73f0d0a"},
+    {file = "multidict-5.1.0-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:4b186eb7d6ae7c06eb4392411189469e6a820da81447f46c0072a41c748ab73f"},
+    {file = "multidict-5.1.0-cp37-cp37m-manylinux2014_i686.whl", hash = "sha256:3a041b76d13706b7fff23b9fc83117c7b8fe8d5fe9e6be45eee72b9baa75f348"},
+    {file = "multidict-5.1.0-cp37-cp37m-manylinux2014_ppc64le.whl", hash = "sha256:051012ccee979b2b06be928a6150d237aec75dd6bf2d1eeeb190baf2b05abc93"},
+    {file = "multidict-5.1.0-cp37-cp37m-manylinux2014_s390x.whl", hash = "sha256:6a4d5ce640e37b0efcc8441caeea8f43a06addace2335bd11151bc02d2ee31f9"},
+    {file = "multidict-5.1.0-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:5cf3443199b83ed9e955f511b5b241fd3ae004e3cb81c58ec10f4fe47c7dce37"},
+    {file = "multidict-5.1.0-cp37-cp37m-win32.whl", hash = "sha256:f200755768dc19c6f4e2b672421e0ebb3dd54c38d5a4f262b872d8cfcc9e93b5"},
+    {file = "multidict-5.1.0-cp37-cp37m-win_amd64.whl", hash = "sha256:05c20b68e512166fddba59a918773ba002fdd77800cad9f55b59790030bab632"},
+    {file = "multidict-5.1.0-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:54fd1e83a184e19c598d5e70ba508196fd0bbdd676ce159feb412a4a6664f952"},
+    {file = "multidict-5.1.0-cp38-cp38-manylinux1_i686.whl", hash = "sha256:0e3c84e6c67eba89c2dbcee08504ba8644ab4284863452450520dad8f1e89b79"},
+    {file = "multidict-5.1.0-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:dc862056f76443a0db4509116c5cd480fe1b6a2d45512a653f9a855cc0517456"},
+    {file = "multidict-5.1.0-cp38-cp38-manylinux2014_i686.whl", hash = "sha256:0e929169f9c090dae0646a011c8b058e5e5fb391466016b39d21745b48817fd7"},
+    {file = "multidict-5.1.0-cp38-cp38-manylinux2014_ppc64le.whl", hash = "sha256:d81eddcb12d608cc08081fa88d046c78afb1bf8107e6feab5d43503fea74a635"},
+    {file = "multidict-5.1.0-cp38-cp38-manylinux2014_s390x.whl", hash = "sha256:585fd452dd7782130d112f7ddf3473ffdd521414674c33876187e101b588738a"},
+    {file = "multidict-5.1.0-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:37e5438e1c78931df5d3c0c78ae049092877e5e9c02dd1ff5abb9cf27a5914ea"},
+    {file = "multidict-5.1.0-cp38-cp38-win32.whl", hash = "sha256:07b42215124aedecc6083f1ce6b7e5ec5b50047afa701f3442054373a6deb656"},
+    {file = "multidict-5.1.0-cp38-cp38-win_amd64.whl", hash = "sha256:929006d3c2d923788ba153ad0de8ed2e5ed39fdbe8e7be21e2f22ed06c6783d3"},
+    {file = "multidict-5.1.0-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:b797515be8743b771aa868f83563f789bbd4b236659ba52243b735d80b29ed93"},
+    {file = "multidict-5.1.0-cp39-cp39-manylinux1_i686.whl", hash = "sha256:d5c65bdf4484872c4af3150aeebe101ba560dcfb34488d9a8ff8dbcd21079647"},
+    {file = "multidict-5.1.0-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:b47a43177a5e65b771b80db71e7be76c0ba23cc8aa73eeeb089ed5219cdbe27d"},
+    {file = "multidict-5.1.0-cp39-cp39-manylinux2014_i686.whl", hash = "sha256:806068d4f86cb06af37cd65821554f98240a19ce646d3cd24e1c33587f313eb8"},
+    {file = "multidict-5.1.0-cp39-cp39-manylinux2014_ppc64le.whl", hash = "sha256:46dd362c2f045095c920162e9307de5ffd0a1bfbba0a6e990b344366f55a30c1"},
+    {file = "multidict-5.1.0-cp39-cp39-manylinux2014_s390x.whl", hash = "sha256:ace010325c787c378afd7f7c1ac66b26313b3344628652eacd149bdd23c68841"},
+    {file = "multidict-5.1.0-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:ecc771ab628ea281517e24fd2c52e8f31c41e66652d07599ad8818abaad38cda"},
+    {file = "multidict-5.1.0-cp39-cp39-win32.whl", hash = "sha256:fc13a9524bc18b6fb6e0dbec3533ba0496bbed167c56d0aabefd965584557d80"},
+    {file = "multidict-5.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:7df80d07818b385f3129180369079bd6934cf70469f99daaebfac89dca288359"},
+    {file = "multidict-5.1.0.tar.gz", hash = "sha256:25b4e5f22d3a37ddf3effc0710ba692cfc792c2b9edfb9c05aefe823256e84d5"},
 ]
 packaging = [
-    {file = "packaging-20.4-py2.py3-none-any.whl", hash = "sha256:998416ba6962ae7fbd6596850b80e17859a5753ba17c32284f67bfff33784181"},
-    {file = "packaging-20.4.tar.gz", hash = "sha256:4357f74f47b9c12db93624a82154e9b120fa8293699949152b22065d556079f8"},
+    {file = "packaging-20.7-py2.py3-none-any.whl", hash = "sha256:eb41423378682dadb7166144a4926e443093863024de508ca5c9737d6bc08376"},
+    {file = "packaging-20.7.tar.gz", hash = "sha256:05af3bb85d320377db281cf254ab050e1a7ebcbf5410685a9a407e18a1f81236"},
 ]
 pluggy = [
     {file = "pluggy-0.13.1-py2.py3-none-any.whl", hash = "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"},
     {file = "pluggy-0.13.1.tar.gz", hash = "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0"},
 ]
 py = [
-    {file = "py-1.8.1-py2.py3-none-any.whl", hash = "sha256:c20fdd83a5dbc0af9efd622bee9a5564e278f6380fffcacc43ba6f43db2813b0"},
-    {file = "py-1.8.1.tar.gz", hash = "sha256:5e27081401262157467ad6e7f851b7aa402c5852dbcb3dae06768434de5752aa"},
+    {file = "py-1.9.0-py2.py3-none-any.whl", hash = "sha256:366389d1db726cd2fcfc79732e75410e5fe4d31db13692115529d34069a043c2"},
+    {file = "py-1.9.0.tar.gz", hash = "sha256:9ca6883ce56b4e8da7e79ac18787889fa5206c79dcc67fb065376cd2fe03f342"},
 ]
 pycodestyle = [
     {file = "pycodestyle-2.6.0-py2.py3-none-any.whl", hash = "sha256:2295e7b2f6b5bd100585ebcb1f616591b652db8a741695b3d8f5d28bdc934367"},
@@ -586,43 +724,86 @@ pytest = [
     {file = "pytest-5.4.3.tar.gz", hash = "sha256:7979331bfcba207414f5e1263b5a0f8f521d0f457318836a7355531ed1a4c7d8"},
 ]
 pytest-cov = [
-    {file = "pytest-cov-2.9.0.tar.gz", hash = "sha256:b6a814b8ed6247bd81ff47f038511b57fe1ce7f4cc25b9106f1a4b106f1d9322"},
-    {file = "pytest_cov-2.9.0-py2.py3-none-any.whl", hash = "sha256:c87dfd8465d865655a8213859f1b4749b43448b5fae465cb981e16d52a811424"},
+    {file = "pytest-cov-2.10.1.tar.gz", hash = "sha256:47bd0ce14056fdd79f93e1713f88fad7bdcc583dcd7783da86ef2f085a0bb88e"},
+    {file = "pytest_cov-2.10.1-py2.py3-none-any.whl", hash = "sha256:45ec2d5182f89a81fc3eb29e3d1ed3113b9e9a873bcddb2a71faaab066110191"},
 ]
 python-dateutil = [
     {file = "python-dateutil-2.8.1.tar.gz", hash = "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c"},
     {file = "python_dateutil-2.8.1-py2.py3-none-any.whl", hash = "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"},
 ]
 requests = [
-    {file = "requests-2.23.0-py2.7.egg", hash = "sha256:5d2d0ffbb515f39417009a46c14256291061ac01ba8f875b90cad137de83beb4"},
-    {file = "requests-2.23.0-py2.py3-none-any.whl", hash = "sha256:43999036bfa82904b6af1d99e4882b560e5e2c68e5c4b0aa03b655f3d7d73fee"},
-    {file = "requests-2.23.0.tar.gz", hash = "sha256:b3f43d496c6daba4493e7c431722aeb7dbc6288f52a6e04e7b6023b0247817e6"},
+    {file = "requests-2.25.0-py2.py3-none-any.whl", hash = "sha256:e786fa28d8c9154e6a4de5d46a1d921b8749f8b74e28bde23768e5e16eece998"},
+    {file = "requests-2.25.0.tar.gz", hash = "sha256:7f1a0b932f4a60a1a65caa4263921bb7d9ee911957e0ae4a23a6dd08185ad5f8"},
 ]
 six = [
     {file = "six-1.15.0-py2.py3-none-any.whl", hash = "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"},
     {file = "six-1.15.0.tar.gz", hash = "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259"},
 ]
 toml = [
-    {file = "toml-0.10.1-py2.py3-none-any.whl", hash = "sha256:bda89d5935c2eac546d648028b9901107a595863cb36bae0c73ac804a9b4ce88"},
-    {file = "toml-0.10.1.tar.gz", hash = "sha256:926b612be1e5ce0634a2ca03470f95169cf16f939018233a670519cb4ac58b0f"},
+    {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
+    {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
 ]
 tox = [
-    {file = "tox-3.15.1-py2.py3-none-any.whl", hash = "sha256:322dfdf007d7d53323f767badcb068a5cfa7c44d8aabb698d131b28cf44e62c4"},
-    {file = "tox-3.15.1.tar.gz", hash = "sha256:8c9ad9b48659d291c5bc78bcabaa4d680d627687154b812fa52baedaa94f9f83"},
+    {file = "tox-3.20.1-py2.py3-none-any.whl", hash = "sha256:42ce19ce5dc2f6d6b1fdc5666c476e1f1e2897359b47e0aa3a5b774f335d57c2"},
+    {file = "tox-3.20.1.tar.gz", hash = "sha256:4321052bfe28f9d85082341ca8e233e3ea901fdd14dab8a5d3fbd810269fbaf6"},
+]
+typing-extensions = [
+    {file = "typing_extensions-3.7.4.3-py2-none-any.whl", hash = "sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f"},
+    {file = "typing_extensions-3.7.4.3-py3-none-any.whl", hash = "sha256:7cb407020f00f7bfc3cb3e7881628838e69d8f3fcab2f64742a5e76b2f841918"},
+    {file = "typing_extensions-3.7.4.3.tar.gz", hash = "sha256:99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c"},
 ]
 urllib3 = [
-    {file = "urllib3-1.25.9-py2.py3-none-any.whl", hash = "sha256:88206b0eb87e6d677d424843ac5209e3fb9d0190d0ee169599165ec25e9d9115"},
-    {file = "urllib3-1.25.9.tar.gz", hash = "sha256:3018294ebefce6572a474f0604c2021e33b3fd8006ecd11d62107a5d2a963527"},
+    {file = "urllib3-1.26.2-py2.py3-none-any.whl", hash = "sha256:d8ff90d979214d7b4f8ce956e80f4028fc6860e4431f731ea4a8c08f23f99473"},
+    {file = "urllib3-1.26.2.tar.gz", hash = "sha256:19188f96923873c92ccb987120ec4acaa12f0461fa9ce5d3d0772bc965a39e08"},
 ]
 virtualenv = [
-    {file = "virtualenv-20.0.21-py2.py3-none-any.whl", hash = "sha256:a730548b27366c5e6cbdf6f97406d861cccece2e22275e8e1a757aeff5e00c70"},
-    {file = "virtualenv-20.0.21.tar.gz", hash = "sha256:a116629d4e7f4d03433b8afa27f43deba09d48bc48f5ecefa4f015a178efb6cf"},
+    {file = "virtualenv-20.2.1-py2.py3-none-any.whl", hash = "sha256:07cff122e9d343140366055f31be4dcd61fd598c69d11cd33a9d9c8df4546dd7"},
+    {file = "virtualenv-20.2.1.tar.gz", hash = "sha256:e0aac7525e880a429764cefd3aaaff54afb5d9f25c82627563603f5d7de5a6e5"},
 ]
 wcwidth = [
-    {file = "wcwidth-0.2.3-py2.py3-none-any.whl", hash = "sha256:980fbf4f3c196c0f329cdcd1e84c554d6a211f18e252e525a0cf4223154a41d6"},
-    {file = "wcwidth-0.2.3.tar.gz", hash = "sha256:edbc2b718b4db6cdf393eefe3a420183947d6aa312505ce6754516f458ff8830"},
+    {file = "wcwidth-0.2.5-py2.py3-none-any.whl", hash = "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784"},
+    {file = "wcwidth-0.2.5.tar.gz", hash = "sha256:c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83"},
+]
+yarl = [
+    {file = "yarl-1.6.3-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:0355a701b3998dcd832d0dc47cc5dedf3874f966ac7f870e0f3a6788d802d434"},
+    {file = "yarl-1.6.3-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:bafb450deef6861815ed579c7a6113a879a6ef58aed4c3a4be54400ae8871478"},
+    {file = "yarl-1.6.3-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:547f7665ad50fa8563150ed079f8e805e63dd85def6674c97efd78eed6c224a6"},
+    {file = "yarl-1.6.3-cp36-cp36m-manylinux2014_i686.whl", hash = "sha256:63f90b20ca654b3ecc7a8d62c03ffa46999595f0167d6450fa8383bab252987e"},
+    {file = "yarl-1.6.3-cp36-cp36m-manylinux2014_ppc64le.whl", hash = "sha256:97b5bdc450d63c3ba30a127d018b866ea94e65655efaf889ebeabc20f7d12406"},
+    {file = "yarl-1.6.3-cp36-cp36m-manylinux2014_s390x.whl", hash = "sha256:d8d07d102f17b68966e2de0e07bfd6e139c7c02ef06d3a0f8d2f0f055e13bb76"},
+    {file = "yarl-1.6.3-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:15263c3b0b47968c1d90daa89f21fcc889bb4b1aac5555580d74565de6836366"},
+    {file = "yarl-1.6.3-cp36-cp36m-win32.whl", hash = "sha256:b5dfc9a40c198334f4f3f55880ecf910adebdcb2a0b9a9c23c9345faa9185721"},
+    {file = "yarl-1.6.3-cp36-cp36m-win_amd64.whl", hash = "sha256:b2e9a456c121e26d13c29251f8267541bd75e6a1ccf9e859179701c36a078643"},
+    {file = "yarl-1.6.3-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:ce3beb46a72d9f2190f9e1027886bfc513702d748047b548b05dab7dfb584d2e"},
+    {file = "yarl-1.6.3-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:2ce4c621d21326a4a5500c25031e102af589edb50c09b321049e388b3934eec3"},
+    {file = "yarl-1.6.3-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:d26608cf178efb8faa5ff0f2d2e77c208f471c5a3709e577a7b3fd0445703ac8"},
+    {file = "yarl-1.6.3-cp37-cp37m-manylinux2014_i686.whl", hash = "sha256:4c5bcfc3ed226bf6419f7a33982fb4b8ec2e45785a0561eb99274ebbf09fdd6a"},
+    {file = "yarl-1.6.3-cp37-cp37m-manylinux2014_ppc64le.whl", hash = "sha256:4736eaee5626db8d9cda9eb5282028cc834e2aeb194e0d8b50217d707e98bb5c"},
+    {file = "yarl-1.6.3-cp37-cp37m-manylinux2014_s390x.whl", hash = "sha256:68dc568889b1c13f1e4745c96b931cc94fdd0defe92a72c2b8ce01091b22e35f"},
+    {file = "yarl-1.6.3-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:7356644cbed76119d0b6bd32ffba704d30d747e0c217109d7979a7bc36c4d970"},
+    {file = "yarl-1.6.3-cp37-cp37m-win32.whl", hash = "sha256:00d7ad91b6583602eb9c1d085a2cf281ada267e9a197e8b7cae487dadbfa293e"},
+    {file = "yarl-1.6.3-cp37-cp37m-win_amd64.whl", hash = "sha256:69ee97c71fee1f63d04c945f56d5d726483c4762845400a6795a3b75d56b6c50"},
+    {file = "yarl-1.6.3-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:e46fba844f4895b36f4c398c5af062a9808d1f26b2999c58909517384d5deda2"},
+    {file = "yarl-1.6.3-cp38-cp38-manylinux1_i686.whl", hash = "sha256:31ede6e8c4329fb81c86706ba8f6bf661a924b53ba191b27aa5fcee5714d18ec"},
+    {file = "yarl-1.6.3-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:fcbb48a93e8699eae920f8d92f7160c03567b421bc17362a9ffbbd706a816f71"},
+    {file = "yarl-1.6.3-cp38-cp38-manylinux2014_i686.whl", hash = "sha256:72a660bdd24497e3e84f5519e57a9ee9220b6f3ac4d45056961bf22838ce20cc"},
+    {file = "yarl-1.6.3-cp38-cp38-manylinux2014_ppc64le.whl", hash = "sha256:324ba3d3c6fee56e2e0b0d09bf5c73824b9f08234339d2b788af65e60040c959"},
+    {file = "yarl-1.6.3-cp38-cp38-manylinux2014_s390x.whl", hash = "sha256:e6b5460dc5ad42ad2b36cca524491dfcaffbfd9c8df50508bddc354e787b8dc2"},
+    {file = "yarl-1.6.3-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:6d6283d8e0631b617edf0fd726353cb76630b83a089a40933043894e7f6721e2"},
+    {file = "yarl-1.6.3-cp38-cp38-win32.whl", hash = "sha256:9ede61b0854e267fd565e7527e2f2eb3ef8858b301319be0604177690e1a3896"},
+    {file = "yarl-1.6.3-cp38-cp38-win_amd64.whl", hash = "sha256:f0b059678fd549c66b89bed03efcabb009075bd131c248ecdf087bdb6faba24a"},
+    {file = "yarl-1.6.3-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:329412812ecfc94a57cd37c9d547579510a9e83c516bc069470db5f75684629e"},
+    {file = "yarl-1.6.3-cp39-cp39-manylinux1_i686.whl", hash = "sha256:c49ff66d479d38ab863c50f7bb27dee97c6627c5fe60697de15529da9c3de724"},
+    {file = "yarl-1.6.3-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:f040bcc6725c821a4c0665f3aa96a4d0805a7aaf2caf266d256b8ed71b9f041c"},
+    {file = "yarl-1.6.3-cp39-cp39-manylinux2014_i686.whl", hash = "sha256:d5c32c82990e4ac4d8150fd7652b972216b204de4e83a122546dce571c1bdf25"},
+    {file = "yarl-1.6.3-cp39-cp39-manylinux2014_ppc64le.whl", hash = "sha256:d597767fcd2c3dc49d6eea360c458b65643d1e4dbed91361cf5e36e53c1f8c96"},
+    {file = "yarl-1.6.3-cp39-cp39-manylinux2014_s390x.whl", hash = "sha256:8aa3decd5e0e852dc68335abf5478a518b41bf2ab2f330fe44916399efedfae0"},
+    {file = "yarl-1.6.3-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:73494d5b71099ae8cb8754f1df131c11d433b387efab7b51849e7e1e851f07a4"},
+    {file = "yarl-1.6.3-cp39-cp39-win32.whl", hash = "sha256:5b883e458058f8d6099e4420f0cc2567989032b5f34b271c0827de9f1079a424"},
+    {file = "yarl-1.6.3-cp39-cp39-win_amd64.whl", hash = "sha256:4953fb0b4fdb7e08b2f3b3be80a00d28c5c8a2056bb066169de00e6501b986b6"},
+    {file = "yarl-1.6.3.tar.gz", hash = "sha256:8a9066529240171b68893d60dca86a763eae2139dd42f42106b03cf4b426bf10"},
 ]
 zipp = [
-    {file = "zipp-3.1.0-py3-none-any.whl", hash = "sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b"},
-    {file = "zipp-3.1.0.tar.gz", hash = "sha256:c599e4d75c98f6798c509911d08a22e6c021d074469042177c8c86fb92eefd96"},
+    {file = "zipp-3.4.0-py3-none-any.whl", hash = "sha256:102c24ef8f171fd729d46599845e95c7ab894a4cf45f5de11a44cc7444fb1108"},
+    {file = "zipp-3.4.0.tar.gz", hash = "sha256:ed5eee1974372595f9e416cc7bbeeb12335201d8081ca8a0743c954d4446e5cb"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ six = "^1.0.0"
 python-dateutil = "^2.0.0"
 lxml = "^4.0.0"
 ifaddr = "^0.1.7"
+aiohttp = "^3.7.3"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.0.0"

--- a/tests/async_server.py
+++ b/tests/async_server.py
@@ -1,0 +1,26 @@
+from aiohttp import web
+
+
+mock_resp = {}
+mock_req = {}
+
+routes = web.RouteTableDef()
+
+
+async def setup_web_server(app, host='localhost', port=8109):
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, host, port)
+    await site.start()
+
+
+@routes.route("*", "/{endpoint:.*}")
+async def handler(request):
+    mock_req.clear()
+    mock_req["endpoint"] = request.match_info['endpoint']
+    mock_req["headers"] = dict(request.headers)
+    mock_req["request"] = request
+    return web.Response(**mock_resp)
+
+app = web.Application()
+app.add_routes(routes)

--- a/tests/async_server.py
+++ b/tests/async_server.py
@@ -1,10 +1,17 @@
 from aiohttp import web
+from tests.helpers import SimpleMock, SimpleMockRequest
 
-
-mock_resp = {}
-mock_req = {}
 
 routes = web.RouteTableDef()
+
+mock_resp = SimpleMock()
+mock_req = SimpleMockRequest()
+
+
+@routes.route("*", "/{_:.*}")
+async def handler(request):
+    mock_req.update(request)
+    return web.Response(**mock_resp)
 
 
 async def setup_web_server(app, host='localhost', port=8109):
@@ -12,15 +19,6 @@ async def setup_web_server(app, host='localhost', port=8109):
     await runner.setup()
     site = web.TCPSite(runner, host, port)
     await site.start()
-
-
-@routes.route("*", "/{endpoint:.*}")
-async def handler(request):
-    mock_req.clear()
-    mock_req["endpoint"] = request.match_info['endpoint']
-    mock_req["headers"] = dict(request.headers)
-    mock_req["request"] = request
-    return web.Response(**mock_resp)
 
 app = web.Application()
 app.add_routes(routes)

--- a/tests/const.py
+++ b/tests/const.py
@@ -1,0 +1,109 @@
+LOCALHOST = "127.0.0.1"
+HTTP_LOCALHOST = "http://%s" % LOCALHOST
+ASYNC_SERVER_PORT = 8109
+ASYNC_HOST = "%s:%r" % (LOCALHOST, ASYNC_SERVER_PORT)
+ASYNC_SERVER_ADDR = "%s:%r" % (HTTP_LOCALHOST, ASYNC_SERVER_PORT)
+
+TEST_CALLACTION_UPNPERROR = """
+    <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+        <s:Body>
+        <s:Fault>
+            <faultcode>s:Client</faultcode>
+            <faultstring>UPnPError</faultstring>
+            <detail>
+            <UPnPError xmlns="urn:schemas-upnp-org:control-1-0">
+                <errorCode>401</errorCode>
+                <errorDescription>Invalid Action</errorDescription>
+            </UPnPError>
+            </detail>
+        </s:Fault>
+        </s:Body>
+    </s:Envelope>
+""".strip()
+
+TEST_CALLACTION_PARAM_MASHAL_OUT_ASYNC = """
+    <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+        <s:Body>
+            <u:GetGenericPortMappingEntryResponse xmlns:u="urn:schemas-upnp-org:service:Layer3Forwarding:1">
+                <NewInternalClient>10.0.0.1</NewInternalClient>
+                <NewExternalPort>51773</NewExternalPort>
+                <NewEnabled>true</NewEnabled>
+            </u:GetGenericPortMappingEntryResponse>
+        </s:Body>
+    </s:Envelope>
+""".strip()
+
+TEST_DEVICE_AUTH = """
+    <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+        <s:Body>
+            <u:GetSubnetMaskResponse xmlns:u="urn:schemas-upnp-org:service:LANHostConfigManagement:1">
+                <NewSubnetMask>255.255.255.0</NewSubnetMask>
+            </u:GetSubnetMaskResponse>
+        </s:Body>
+    </s:Envelope>
+""".strip()
+
+TEST_CALLACTION_NOPARAM = """
+    <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+        <s:Body>
+            <u:GetAddressRangeResponse xmlns:u="urn:schemas-upnp-org:service:LANHostConfigManagement:1">
+                <NewMinAddress>10.0.0.2</NewMinAddress>
+                <NewMaxAddress>10.0.0.254</NewMaxAddress>
+            </u:GetAddressRangeResponse>
+        </s:Body>
+    </s:Envelope>
+"""
+
+TEST_CALLACTION_PARAM = """
+    <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+        <s:Body>
+            <u:GetGenericPortMappingEntryResponse xmlns:u="urn:schemas-upnp-org:service:Layer3Forwarding:1">
+                <NewInternalClient>10.0.0.1</NewInternalClient>
+                <NewExternalPort>51773</NewExternalPort>
+                <NewEnabled>true</NewEnabled>
+            </u:GetGenericPortMappingEntryResponse>
+        </s:Body>
+    </s:Envelope>
+"""
+
+TEST_MISSING_ERROR_CODE_ELEMENT = """
+    <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+        <s:Body>
+        <s:Fault>
+            <faultcode>s:Client</faultcode>
+            <faultstring>UPnPError</faultstring>
+            <detail>
+            <UPnPError xmlns="urn:schemas-upnp-org:control-1-0">
+                <errorDescription>Invalid Action</errorDescription>
+            </UPnPError>
+            </detail>
+        </s:Fault>
+        </s:Body>
+    </s:Envelope>
+""".strip()
+
+TEST_MISSING_ERROR_DESCRIPTION_ELEMENT = """
+    <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+        <s:Body>
+        <s:Fault>
+            <faultcode>s:Client</faultcode>
+            <faultstring>UPnPError</faultstring>
+            <detail>
+            <UPnPError xmlns="urn:schemas-upnp-org:control-1-0">
+                <errorCode>401</errorCode>
+            </UPnPError>
+            </detail>
+        </s:Fault>
+        </s:Body>
+    </s:Envelope>
+""".strip()
+
+TEST_MISSING_RESPONSE_ELEMENT = """
+    <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+        <s:Body>
+            <u:SomeOtherElement xmlns:u="urn:schemas-upnp-org:service:Layer3Forwarding:1">
+                <NewEnabled>true</NewEnabled>
+            </u:SomeOtherElement>
+        </s:Body>
+    </s:Envelope>
+"""

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,26 @@
+from functools import wraps
+
+
+def async_test(f):
+    """
+    Decorator to create asyncio context for asyncio methods or functions.
+    """
+    @wraps(f)
+    def g(*args, **kwargs):
+        args[0].loop.run_until_complete(f(*args, **kwargs))
+    return g
+
+
+def add_async_test(f):
+    """
+    Test both the synchronous and async methods of the device (server).
+    """
+    @wraps(f)
+    def g(*args, **kwargs):
+        f(*args, **kwargs)  # run the original test
+        async_args = [a for a in args]  # make mutable copy of args
+        server = async_args[0].server  # save reference to self.server
+        async_args[0].server = async_args[0].async_server  # set copy.server to async_server
+        f(*async_args, **kwargs)  # run the test using the async instance
+        async_args[0].server = server  # point self.server back to original
+    return g

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,45 @@
+import unittest
+
+import upnpclient as upnp
+
+
+class TestErrors(unittest.TestCase):
+    desc = upnp.errors.ERR_CODE_DESCRIPTIONS
+
+    def test_existing_err(self):
+        for key, value in self.desc._descriptions.items():
+            self.assertEqual(self.desc[key], value)
+
+    def test_non_integer(self):
+        try:
+            self.desc["a string"]
+            raise Exception("Should have raised KeyError.")
+        except KeyError as exc:
+            self.assertEqual(str(exc), "\"'key' must be an integer\"")
+
+    def test_reserved(self):
+        for i in range(606, 612 + 1):  # 606-612
+            self.assertEqual(
+                self.desc[i], "These ErrorCodes are reserved for UPnP DeviceSecurity."
+            )
+
+    def test_common_action(self):
+        for i in range(613, 699 + 1):
+            self.assertEqual(
+                self.desc[i],
+                "Common action errors. Defined by UPnP Forum Technical Committee.",
+            )
+
+    def test_action_specific_committee(self):
+        for i in range(700, 799 + 1):
+            self.assertEqual(
+                self.desc[i],
+                "Action-specific errors defined by UPnP Forum working committee.",
+            )
+
+    def test_action_specific_vendor(self):
+        for i in range(800, 899 + 1):
+            self.assertEqual(
+                self.desc[i],
+                "Action-specific errors for non-standard actions. Defined by UPnP vendor.",
+            )

--- a/tests/test_upnp.py
+++ b/tests/test_upnp.py
@@ -1,0 +1,387 @@
+import unittest
+import mock
+import binascii
+import datetime
+import base64
+from uuid import UUID
+
+try:
+    from urllib.parse import ParseResult
+except ImportError:
+    from urlparse import ParseResult
+
+import upnpclient as upnp
+
+
+class TestUPnPClient(unittest.TestCase):
+    @mock.patch("upnpclient.ssdp.Device", return_value="test string")
+    @mock.patch("upnpclient.ssdp.scan")
+    def test_discover(self, mock_scan, mock_server):
+        """
+        discover() should call netdisco's scan function and return a list of unique servers.
+        """
+        url = "http://www.example.com"
+        entry = mock.Mock()
+        entry.location = url
+        mock_scan.return_value = [entry, entry]
+        ret = upnp.discover()
+        mock_scan.assert_called()
+        mock_server.assert_called_with(url)
+        self.assertEqual(ret, ["test string"])
+
+    @mock.patch("upnpclient.ssdp.Device", side_effect=Exception)
+    @mock.patch("upnpclient.ssdp.scan")
+    def test_discover_exception(self, mock_scan, mock_server):
+        """
+        If unable to read a discovered server's root XML file, it should not appear in the list.
+        """
+        url = "http://www.example.com"
+        entry = mock.Mock()
+        entry.location = url
+        mock_scan.return_value = [entry]
+        ret = upnp.discover()
+        mock_scan.assert_called()
+        mock_server.assert_called_with(url)
+        self.assertEqual(ret, [])
+
+    def test_validate_date(self):
+        """
+        Should validate the 'date' type.
+        """
+        ret = upnp.Action.validate_arg("2017-08-11", dict(datatype="date"))
+        self.assertEqual(ret, (True, set()))
+
+    def test_validate_bad_date(self):
+        """
+        Bad 'date' type should fail validation.
+        """
+        valid, reasons = upnp.Action.validate_arg("2017-13-13", dict(datatype="date"))
+        print(reasons)
+        self.assertTrue(reasons)
+        self.assertFalse(valid)
+
+    def test_validate_date_with_time(self):
+        """
+        Should raise a ValidationError if a 'date' contains a time.
+        """
+        valid, reasons = upnp.Action.validate_arg(
+            "2017-13-13T12:34:56", dict(datatype="date")
+        )
+        print(reasons)
+        self.assertTrue(reasons)
+        self.assertFalse(valid)
+
+    def test_marshal_date(self):
+        """
+        Should parse a valid date into a `datetime.date` object.
+        """
+        marshalled, val = upnp.marshal.marshal_value("date", "2017-08-11")
+        self.assertTrue(marshalled)
+        self.assertIsInstance(val, datetime.date)
+        tests = dict(year=2017, month=8, day=11)
+        for key, value in tests.items():
+            self.assertEqual(getattr(val, key), value)
+
+    def test_marshal_datetime(self):
+        """
+        Should parse and marshal a 'dateTime' into a timezone naive `datetime.datetime`.
+        """
+        marshalled, val = upnp.marshal.marshal_value("dateTime", "2017-08-11T12:34:56")
+        self.assertTrue(marshalled)
+        self.assertIsInstance(val, datetime.datetime)
+        tests = dict(year=2017, month=8, day=11, hour=12, minute=34, second=56)
+        for key, value in tests.items():
+            self.assertEqual(getattr(val, key), value)
+        self.assertEqual(val.tzinfo, None)
+
+    def test_marshal_datetime_tz(self):
+        """
+        Should parse and marshal a 'dateTime.tz' into a timezone aware `datetime.datetime`.
+        """
+        marshalled, val = upnp.marshal.marshal_value(
+            "dateTime.tz", "2017-08-11T12:34:56+1:00"
+        )
+        self.assertTrue(marshalled)
+        self.assertIsInstance(val, datetime.datetime)
+        tests = dict(year=2017, month=8, day=11, hour=12, minute=34, second=56)
+        for key, value in tests.items():
+            self.assertEqual(getattr(val, key), value)
+        self.assertEqual(val.utcoffset(), datetime.timedelta(hours=1))
+
+    def test_validate_time_illegal_tz(self):
+        """
+        Should fail validation if 'time' contains a timezone.
+        """
+        valid, reasons = upnp.Action.validate_arg("12:34:56+1:00", dict(datatype="time"))
+        print(reasons)
+        self.assertTrue(reasons)
+        self.assertFalse(valid)
+
+    def test_marshal_time(self):
+        """
+        Should parse a 'time' into a timezone naive `datetime.time`.
+        """
+        marshalled, val = upnp.marshal.marshal_value("time", "12:34:56")
+        self.assertTrue(marshalled)
+        self.assertIsInstance(val, datetime.time)
+        tests = dict(hour=12, minute=34, second=56)
+        for key, value in tests.items():
+            self.assertEqual(getattr(val, key), value)
+        self.assertEqual(val.tzinfo, None)
+
+    def test_marshal_time_tz(self):
+        """
+        Should parse a 'time.tz' into a timezone aware `datetime.time`.
+        """
+        marshalled, val = upnp.marshal.marshal_value("time.tz", "12:34:56+1:00")
+        self.assertTrue(marshalled)
+        self.assertIsInstance(val, datetime.time)
+        tests = dict(hour=12, minute=34, second=56)
+        for key, value in tests.items():
+            self.assertEqual(getattr(val, key), value)
+        self.assertEqual(val.utcoffset(), datetime.timedelta(hours=1))
+
+    def test_marshal_bool(self):
+        """
+        Should parse a 'boolean' into a `bool`.
+        """
+        valid_true = ("1", "true", "TRUE", "True", "yes", "YES", "Yes")
+        valid_false = ("0", "false", "FALSE", "False", "no", "NO", "No")
+        tests = list(zip(valid_true, [True] * len(valid_true))) + list(
+            zip(valid_false, [False] * len(valid_false))
+        )
+        for item, test in tests:
+            marshalled, val = upnp.marshal.marshal_value("boolean", item)
+            self.assertTrue(marshalled)
+            self.assertEqual(val, test)
+
+    def test_validate_bad_bool(self):
+        """
+        Should raise a ValidationError if an invalid 'boolean' is provided.
+        """
+        valid, reasons = upnp.Action.validate_arg("2", dict(datatype="boolean"))
+        print(reasons)
+        self.assertTrue(reasons)
+        self.assertFalse(valid)
+
+    def test_validate_base64(self):
+        """
+        Should validate a 'bin.base64' value.
+        """
+        bstring = "Hello, World!".encode("utf8")
+        encoded = base64.b64encode(bstring)
+        valid, reasons = upnp.Action.validate_arg(encoded, dict(datatype="bin.base64"))
+        print(reasons)
+        self.assertFalse(reasons)
+        self.assertTrue(valid)
+
+    def test_marshal_base64(self):
+        """
+        Should simply leave the base64 string as it is.
+        """
+        bstring = "Hello, World!".encode("utf8")
+        encoded = base64.b64encode(bstring)
+        marshalled, val = upnp.marshal.marshal_value("bin.base64", encoded)
+        self.assertTrue(marshalled)
+        self.assertEqual(val, encoded)
+
+    def test_validate_hex(self):
+        """
+        Should validate a 'bin.hex' value.
+        """
+        bstring = "Hello, World!".encode("ascii")
+        valid, reasons = upnp.Action.validate_arg(
+            binascii.hexlify(bstring), dict(datatype="bin.hex")
+        )
+        print(reasons)
+        self.assertFalse(reasons)
+        self.assertTrue(valid)
+
+    def test_marshal_hex(self):
+        """
+        Should simply leave the hex string as it is.
+        """
+        bstring = "Hello, World!".encode("ascii")
+        encoded = binascii.hexlify(bstring)
+        marshalled, val = upnp.marshal.marshal_value("bin.hex", encoded)
+        self.assertTrue(marshalled)
+        self.assertEqual(val, encoded)
+
+    def test_validate_uri(self):
+        """
+        Should validate a 'uri' value.
+        """
+        uri = "https://media.giphy.com/media/22kxQ12cxyEww/giphy.gif?something=variable"
+        valid, reasons = upnp.Action.validate_arg(uri, dict(datatype="uri"))
+        print(reasons)
+        self.assertFalse(reasons)
+        self.assertTrue(valid)
+
+    def test_marshal_uri(self):
+        """
+        Should parse a 'uri' value into a `ParseResult`.
+        """
+        uri = "https://media.giphy.com/media/22kxQ12cxyEww/giphy.gif?something=variable"
+        marshalled, val = upnp.marshal.marshal_value("uri", uri)
+        self.assertTrue(marshalled)
+        self.assertIsInstance(val, ParseResult)
+
+    def test_validate_uuid(self):
+        """
+        Should validate a 'uuid' value.
+        """
+        uuid = "bec6d681-a6af-4e7d-8b31-bcb78018c814"
+        valid, reasons = upnp.Action.validate_arg(uuid, dict(datatype="uuid"))
+        print(reasons)
+        self.assertFalse(reasons)
+        self.assertTrue(valid)
+
+    def test_validate_bad_uuid(self):
+        """
+        Should reject badly formatted 'uuid' values.
+        """
+        uuid = "bec-6d681a6af-4e7d-8b31-bcb78018c814"
+        valid, reasons = upnp.Action.validate_arg(uuid, dict(datatype="uuid"))
+        self.assertTrue(reasons)
+        self.assertFalse(valid)
+
+    def test_marshal_uuid(self):
+        """
+        Should parse a 'uuid' into a `uuid.UUID`.
+        """
+        uuid = "bec6d681-a6af-4e7d-8b31-bcb78018c814"
+        marshalled, val = upnp.marshal.marshal_value("uuid", uuid)
+        self.assertTrue(marshalled)
+        self.assertIsInstance(val, UUID)
+
+    def test_validate_subscription_response(self):
+        """
+        Should validate the sub response and return sid and timeout.
+        """
+        sid = "abcdef"
+        timeout = 123
+        resp = mock.Mock()
+        resp.headers = dict(SID=sid, Timeout="Second-%s" % timeout)
+        rsid, rtimeout = upnp.Service.validate_subscription_response(resp)
+        self.assertEqual(rsid, sid)
+        self.assertEqual(rtimeout, timeout)
+
+    def test_validate_subscription_response_caps(self):
+        """
+        Should validate the sub response and return sid and timeout regardless of capitalisation.
+        """
+        sid = "abcdef"
+        timeout = 123
+        resp = mock.Mock()
+        resp.headers = dict(sid=sid, TIMEOUT="SeCoNd-%s" % timeout)
+        rsid, rtimeout = upnp.Service.validate_subscription_response(resp)
+        self.assertEqual(rsid, sid)
+        self.assertEqual(rtimeout, timeout)
+
+    def test_validate_subscription_response_infinite(self):
+        """
+        Should validate the sub response and return None as the timeout.
+        """
+        sid = "abcdef"
+        timeout = "infinite"
+        resp = mock.Mock()
+        resp.headers = dict(SID=sid, Timeout="Second-%s" % timeout)
+        rsid, rtimeout = upnp.Service.validate_subscription_response(resp)
+        self.assertEqual(rsid, sid)
+        self.assertEqual(rtimeout, None)
+
+    def test_validate_subscription_response_no_timeout(self):
+        """
+        Should raise UnexpectedResponse if timeout is missing.
+        """
+        resp = mock.Mock()
+        resp.headers = dict(SID="abcdef")
+        self.assertRaises(
+            upnp.UnexpectedResponse, upnp.Service.validate_subscription_response, resp
+        )
+
+    def test_validate_subscription_response_no_sid(self):
+        """
+        Should raise UnexpectedResponse if sid is missing.
+        """
+        resp = mock.Mock()
+        resp.headers = dict(Timeout="Second-123")
+        self.assertRaises(
+            upnp.UnexpectedResponse, upnp.Service.validate_subscription_response, resp
+        )
+
+    def test_validate_subscription_response_bad_timeout(self):
+        """
+        Should raise UnexpectedResponse if timeout is in the wrong format.
+        """
+        resp = mock.Mock()
+        resp.headers = dict(SID="abcdef", Timeout="123")
+        self.assertRaises(
+            upnp.UnexpectedResponse, upnp.Service.validate_subscription_response, resp
+        )
+
+    def test_validate_subscription_response_bad_timeout2(self):
+        """
+        Should raise UnexpectedResponse if timeout is not an int/infinite.
+        """
+        resp = mock.Mock()
+        resp.headers = dict(SID="abcdef", Timeout="Second-abc")
+        self.assertRaises(
+            upnp.UnexpectedResponse, upnp.Service.validate_subscription_response, resp
+        )
+
+    def test_validate_subscription_renewal_response(self):
+        """
+        Should validate the sub renewal response and return the timeout.
+        """
+        timeout = 123
+        resp = mock.Mock()
+        resp.headers = dict(Timeout="Second-%s" % timeout)
+        rtimeout = upnp.Service.validate_subscription_renewal_response(resp)
+        self.assertEqual(rtimeout, timeout)
+
+    def test_validate_subscription_renewal_response_infinite(self):
+        """
+        Should validate the sub renewal response and return None as the timeout.
+        """
+        timeout = "infinite"
+        resp = mock.Mock()
+        resp.headers = dict(Timeout="Second-%s" % timeout)
+        rtimeout = upnp.Service.validate_subscription_renewal_response(resp)
+        self.assertEqual(rtimeout, None)
+
+    def test_validate_subscription_renewal_response_no_timeout(self):
+        """
+        Should raise UnexpectedResponse if timeout is missing.
+        """
+        resp = mock.Mock()
+        resp.headers = dict()
+        self.assertRaises(
+            upnp.UnexpectedResponse,
+            upnp.Service.validate_subscription_renewal_response,
+            resp,
+        )
+
+    def test_validate_subscription_renewal_response_bad_timeout(self):
+        """
+        Should raise UnexpectedResponse if timeout is in the wrong format.
+        """
+        resp = mock.Mock()
+        resp.headers = dict(Timeout="123")
+        self.assertRaises(
+            upnp.UnexpectedResponse,
+            upnp.Service.validate_subscription_renewal_response,
+            resp,
+        )
+
+    def test_validate_subscription_renewal_response_bad_timeout2(self):
+        """
+        Should raise UnexpectedResponse if timeout is not an int/infinite.
+        """
+        resp = mock.Mock()
+        resp.headers = dict(Timeout="Second-abc")
+        self.assertRaises(
+            upnp.UnexpectedResponse,
+            upnp.Service.validate_subscription_renewal_response,
+            resp,
+        )

--- a/tests/test_upnpclient.py
+++ b/tests/test_upnpclient.py
@@ -2,33 +2,46 @@ import unittest
 import threading
 import os.path as path
 import os
-import datetime
-import base64
-import binascii
-from uuid import UUID
-
+import asyncio
+import aiohttp
 import mock
 import requests
 from requests.compat import basestring
 from lxml import etree
-
-import upnpclient as upnp
-
-
+from base64 import b64encode
 try:
     import http.server as httpserver
 except ImportError:
     import SimpleHTTPServer as httpserver
-
 try:
     import socketserver as sockserver
 except ImportError:
     import SocketServer as sockserver
 
-try:
-    from urllib.parse import ParseResult
-except ImportError:
-    from urlparse import ParseResult
+import upnpclient as upnp
+from tests.helpers import async_test, add_async_test
+from tests.async_server import (
+    mock_resp,
+    mock_req,
+    setup_web_server,
+    app,
+)
+
+from tests.const import (
+    ASYNC_HOST,
+    ASYNC_SERVER_ADDR,
+    ASYNC_SERVER_PORT,
+    HTTP_LOCALHOST,
+    LOCALHOST,
+    TEST_CALLACTION_NOPARAM,
+    TEST_CALLACTION_PARAM,
+    TEST_CALLACTION_PARAM_MASHAL_OUT_ASYNC,
+    TEST_CALLACTION_UPNPERROR,
+    TEST_DEVICE_AUTH,
+    TEST_MISSING_ERROR_CODE_ELEMENT,
+    TEST_MISSING_ERROR_DESCRIPTION_ELEMENT,
+    TEST_MISSING_RESPONSE_ELEMENT,
+)
 
 
 class EndPrematurelyException(Exception):
@@ -46,7 +59,7 @@ class TestUPnPClientWithServer(unittest.TestCase):
         # to change its working directory like the py3 one does.
         os.chdir(path.join(path.dirname(path.realpath(__file__)), "xml"))
         cls.httpd = sockserver.TCPServer(
-            ("127.0.0.1", 0), httpserver.SimpleHTTPRequestHandler
+            (LOCALHOST, 0), httpserver.SimpleHTTPRequestHandler
         )
         cls.httpd_thread = threading.Thread(target=cls.httpd.serve_forever)
         cls.httpd_thread.daemon = True
@@ -57,203 +70,267 @@ class TestUPnPClientWithServer(unittest.TestCase):
             with open("upnp/IGD.xml.templ") as in_f:
                 out_f.write(in_f.read().format(port=cls.httpd_port))
 
+        cls.xml_resource = "%s:%s/upnp/IGD.xml" % (HTTP_LOCALHOST, cls.httpd_port)
+
+        cls.loop = asyncio.get_event_loop()
+        cls.loop.run_until_complete(
+            setup_web_server(app, host=LOCALHOST, port=ASYNC_SERVER_PORT)
+        )
+
     @classmethod
     def tearDownClass(cls):
         """
         Shut down the HTTP server and delete the IGD.xml file.
         """
         cls.httpd.shutdown()
+        cls.loop.close()
         try:
             os.unlink("upnp/IGD.xml")
         except OSError:
             pass
 
     def setUp(self):
-        self.server = upnp.Device("http://127.0.0.1:%s/upnp/IGD.xml" % self.httpd_port)
+        self.server = upnp.Device(self.xml_resource)
+
+        async def run():
+            self.session = aiohttp.ClientSession()
+            self.async_server = upnp.Device(
+                self.xml_resource,
+                use_async=True,
+                session=self.session
+            )
+            await self.async_server.async_init()
+        self.loop.run_until_complete(run())
+
+    def tearDown(self):
+        mock_resp.clear()
+
+        async def run():
+            await self.session.close()
+        self.loop.run_until_complete(run())
 
     @mock.patch("requests.post")
     def test_device_auth(self, mock_post):
         auth = ("myuser", "mypassword")
-        device = upnp.Device(
-            "http://127.0.0.1:%s/upnp/IGD.xml" % self.httpd_port, http_auth=auth
-        )
+        device = upnp.Device(self.xml_resource, http_auth=auth)
         ret = mock.Mock()
-        ret.content = """
-        <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
-           <s:Body>
-              <u:GetSubnetMaskResponse xmlns:u="urn:schemas-upnp-org:service:LANHostConfigManagement:1">
-                 <NewSubnetMask>255.255.255.0</NewSubnetMask>
-              </u:GetSubnetMaskResponse>
-           </s:Body>
-        </s:Envelope>
-        """
+        ret.content = TEST_DEVICE_AUTH
         mock_post.return_value = ret
         ret = device("GetSubnetMask")
         _, kwargs = mock_post.call_args
         self.assertIn("auth", kwargs)
         self.assertEqual(kwargs["auth"], auth)
 
+    @async_test
+    async def test_device_auth_async(self):
+        auth = ("myuser", "mypassword")
+        device = upnp.Device(self.xml_resource, http_auth=auth, use_async=True)
+        await device.async_init()
+        device.find_action("GetSubnetMask").url = ASYNC_SERVER_ADDR
+        mock_resp["text"] = TEST_DEVICE_AUTH
+        await device("GetSubnetMask")
+        basic_auth_string = f"{auth[0]}:{auth[1]}"
+        b64 = b64encode(basic_auth_string.encode("utf-8")).decode()
+        self.assertEqual("Basic %s" % b64, mock_req["headers"]["Authorization"])
+        await device.session.close()
+
     @mock.patch("requests.post")
     def test_device_auth_call_override(self, mock_post):
         dev_auth = ("devuser", "devpassword")
         call_auth = ("calluser", "callpassword")
-        device = upnp.Device(
-            "http://127.0.0.1:%s/upnp/IGD.xml" % self.httpd_port, http_auth=dev_auth
-        )
+        device = upnp.Device(self.xml_resource, http_auth=dev_auth)
         ret = mock.Mock()
-        ret.content = """
-        <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
-           <s:Body>
-              <u:GetSubnetMaskResponse xmlns:u="urn:schemas-upnp-org:service:LANHostConfigManagement:1">
-                 <NewSubnetMask>255.255.255.0</NewSubnetMask>
-              </u:GetSubnetMaskResponse>
-           </s:Body>
-        </s:Envelope>
-        """
+        ret.content = TEST_DEVICE_AUTH
         mock_post.return_value = ret
         ret = device("GetSubnetMask", http_auth=call_auth)
         _, kwargs = mock_post.call_args
         self.assertIn("auth", kwargs)
         self.assertEqual(kwargs["auth"], call_auth)
 
+    @async_test
+    async def test_device_auth_call_override_async(self):
+        dev_auth = ("devuser", "devpassword")
+        call_auth = ("calluser", "callpassword")
+        device = upnp.Device(self.xml_resource, http_auth=dev_auth, use_async=True)
+        await device.async_init()
+        device.find_action("GetSubnetMask").url = ASYNC_SERVER_ADDR
+        mock_resp["text"] = TEST_DEVICE_AUTH
+        await device("GetSubnetMask", http_auth=call_auth)
+        basic_auth_string = f"{call_auth[0]}:{call_auth[1]}"
+        b64 = b64encode(basic_auth_string.encode("utf-8")).decode()
+        self.assertEqual("Basic %s" % b64, mock_req["headers"]["Authorization"])
+
     @mock.patch("requests.post")
     def test_device_auth_call_override_none(self, mock_post):
         dev_auth = ("devuser", "devpassword")
         call_auth = None
-        device = upnp.Device(
-            "http://127.0.0.1:%s/upnp/IGD.xml" % self.httpd_port, http_auth=dev_auth
-        )
+        device = upnp.Device(self.xml_resource, http_auth=dev_auth)
         ret = mock.Mock()
-        ret.content = """
-        <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
-           <s:Body>
-              <u:GetSubnetMaskResponse xmlns:u="urn:schemas-upnp-org:service:LANHostConfigManagement:1">
-                 <NewSubnetMask>255.255.255.0</NewSubnetMask>
-              </u:GetSubnetMaskResponse>
-           </s:Body>
-        </s:Envelope>
-        """
+        ret.content = TEST_DEVICE_AUTH
         mock_post.return_value = ret
         ret = device("GetSubnetMask", http_auth=call_auth)
         _, kwargs = mock_post.call_args
         self.assertIn("auth", kwargs)
         self.assertEqual(kwargs["auth"], dev_auth)
 
+    @async_test
+    async def test_device_auth_call_override_none_async(self):
+        auth = ("myuser", "mypassword")
+        call_auth = None
+        device = upnp.Device(self.xml_resource, http_auth=auth, use_async=True)
+        await device.async_init()
+        device.find_action("GetSubnetMask").url = ASYNC_SERVER_ADDR
+        mock_resp["text"] = TEST_DEVICE_AUTH
+        await device("GetSubnetMask", http_auth=call_auth)
+        basic_auth_string = f"{auth[0]}:{auth[1]}"
+        b64 = b64encode(basic_auth_string.encode("utf-8")).decode()
+        self.assertEqual("Basic %s" % b64, mock_req["headers"]["Authorization"])
+        await device.session.close()
+
     @mock.patch("requests.post")
     def test_device_auth_none_override(self, mock_post):
         dev_auth = None
         call_auth = ("calluser", "callpassword")
-        device = upnp.Device(
-            "http://127.0.0.1:%s/upnp/IGD.xml" % self.httpd_port, http_auth=dev_auth
-        )
+        device = upnp.Device(self.xml_resource, http_auth=dev_auth)
         ret = mock.Mock()
-        ret.content = """
-        <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
-           <s:Body>
-              <u:GetSubnetMaskResponse xmlns:u="urn:schemas-upnp-org:service:LANHostConfigManagement:1">
-                 <NewSubnetMask>255.255.255.0</NewSubnetMask>
-              </u:GetSubnetMaskResponse>
-           </s:Body>
-        </s:Envelope>
-        """
+        ret.content = TEST_DEVICE_AUTH
         mock_post.return_value = ret
         ret = device("GetSubnetMask", http_auth=call_auth)
         _, kwargs = mock_post.call_args
         self.assertIn("auth", kwargs)
         self.assertEqual(kwargs["auth"], call_auth)
 
+    @async_test
+    async def test_device_auth_none_override_async(self):
+        auth = None
+        call_auth = ("myuser", "mypassword")
+        device = upnp.Device(self.xml_resource, http_auth=auth, use_async=True)
+        await device.async_init()
+        device.find_action("GetSubnetMask").url = ASYNC_SERVER_ADDR
+        mock_resp["text"] = TEST_DEVICE_AUTH
+        await device("GetSubnetMask", http_auth=call_auth)
+        basic_auth_string = f"{call_auth[0]}:{call_auth[1]}"
+        b64 = b64encode(basic_auth_string.encode("utf-8")).decode()
+        self.assertEqual("Basic %s" % b64, mock_req["headers"]["Authorization"])
+        await device.session.close()
+
     @mock.patch("requests.post")
     def test_device_headers(self, mock_post):
         headers = dict(test="device")
-        device = upnp.Device(
-            "http://127.0.0.1:%s/upnp/IGD.xml" % self.httpd_port, http_headers=headers
-        )
+        device = upnp.Device(self.xml_resource, http_headers=headers)
         ret = mock.Mock()
-        ret.content = """
-        <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
-           <s:Body>
-              <u:GetSubnetMaskResponse xmlns:u="urn:schemas-upnp-org:service:LANHostConfigManagement:1">
-                 <NewSubnetMask>255.255.255.0</NewSubnetMask>
-              </u:GetSubnetMaskResponse>
-           </s:Body>
-        </s:Envelope>
-        """
+        ret.content = TEST_DEVICE_AUTH
         mock_post.return_value = ret
         ret = device("GetSubnetMask")
         _, kwargs = mock_post.call_args
         self.assertEqual(kwargs["headers"]["test"], "device")
 
+    @async_test
+    async def test_device_headers_async(self):
+        headers = dict(test="device")
+        device = upnp.Device(self.xml_resource, http_headers=headers, use_async=True)
+        await device.async_init()
+        device.find_action("GetSubnetMask").url = ASYNC_SERVER_ADDR
+        mock_resp["text"] = TEST_DEVICE_AUTH
+        await device("GetSubnetMask")
+        self.assertEqual(mock_req["headers"]["test"], "device")
+        await device.session.close()
+
     @mock.patch("requests.post")
     def test_device_headers_call_override(self, mock_post):
         dev_headers = dict(test="device")
         call_headers = dict(test="call")
-        device = upnp.Device(
-            "http://127.0.0.1:%s/upnp/IGD.xml" % self.httpd_port, http_headers=dev_headers
-        )
+        device = upnp.Device(self.xml_resource, http_headers=dev_headers)
         ret = mock.Mock()
-        ret.content = """
-        <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
-           <s:Body>
-              <u:GetSubnetMaskResponse xmlns:u="urn:schemas-upnp-org:service:LANHostConfigManagement:1">
-                 <NewSubnetMask>255.255.255.0</NewSubnetMask>
-              </u:GetSubnetMaskResponse>
-           </s:Body>
-        </s:Envelope>
-        """
+        ret.content = TEST_DEVICE_AUTH
         mock_post.return_value = ret
         ret = device("GetSubnetMask", http_headers=call_headers)
         _, kwargs = mock_post.call_args
         self.assertEqual(kwargs["headers"]["test"], "call")
+
+    @async_test
+    async def test_device_headers_call_override_async(self):
+        dev_headers = dict(test="device")
+        call_headers = dict(test="call")
+        device = upnp.Device(self.xml_resource, http_headers=dev_headers, use_async=True)
+        await device.async_init()
+        device.find_action("GetSubnetMask").url = ASYNC_SERVER_ADDR
+        mock_resp["text"] = TEST_DEVICE_AUTH
+        await device("GetSubnetMask", http_headers=call_headers)
+        self.assertEqual(mock_req["headers"]["test"], "call")
+        await device.session.close()
 
     @mock.patch("requests.post")
     def test_device_headers_call_override_none(self, mock_post):
         dev_headers = dict(test="device")
         call_headers = None
-        device = upnp.Device(
-            "http://127.0.0.1:%s/upnp/IGD.xml" % self.httpd_port, http_headers=dev_headers
-        )
+        device = upnp.Device(self.xml_resource, http_headers=dev_headers)
         ret = mock.Mock()
-        ret.content = """
-        <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
-           <s:Body>
-              <u:GetSubnetMaskResponse xmlns:u="urn:schemas-upnp-org:service:LANHostConfigManagement:1">
-                 <NewSubnetMask>255.255.255.0</NewSubnetMask>
-              </u:GetSubnetMaskResponse>
-           </s:Body>
-        </s:Envelope>
-        """
+        ret.content = TEST_DEVICE_AUTH
         mock_post.return_value = ret
         ret = device("GetSubnetMask", http_headers=call_headers)
         _, kwargs = mock_post.call_args
         self.assertEqual(kwargs["headers"]["test"], "device")
 
+    @async_test
+    async def test_device_headers_call_override_none_async(self):
+        dev_headers = dict(test="device")
+        call_headers = None
+        device = upnp.Device(self.xml_resource, http_headers=dev_headers, use_async=True)
+        await device.async_init()
+        device.find_action("GetSubnetMask").url = ASYNC_SERVER_ADDR
+        mock_resp["text"] = TEST_DEVICE_AUTH
+        await device("GetSubnetMask", http_headers=call_headers)
+        self.assertEqual(mock_req["headers"]["test"], "device")
+        await device.session.close()
+
     @mock.patch("requests.post")
     def test_device_headers_none_override(self, mock_post):
         dev_headers = None
         call_headers = dict(test="call")
-        device = upnp.Device(
-            "http://127.0.0.1:%s/upnp/IGD.xml" % self.httpd_port, http_headers=dev_headers
-        )
+        device = upnp.Device(self.xml_resource, http_headers=dev_headers)
         ret = mock.Mock()
-        ret.content = """
-        <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
-           <s:Body>
-              <u:GetSubnetMaskResponse xmlns:u="urn:schemas-upnp-org:service:LANHostConfigManagement:1">
-                 <NewSubnetMask>255.255.255.0</NewSubnetMask>
-              </u:GetSubnetMaskResponse>
-           </s:Body>
-        </s:Envelope>
-        """
+        ret.content = TEST_DEVICE_AUTH
         mock_post.return_value = ret
         ret = device("GetSubnetMask", http_headers=call_headers)
         _, kwargs = mock_post.call_args
         self.assertEqual(kwargs["headers"]["test"], "call")
 
+    @async_test
+    async def test_device_headers_none_override_async(self):
+        dev_headers = None
+        call_headers = dict(test="call")
+        device = upnp.Device(self.xml_resource, http_headers=dev_headers, use_async=True)
+        await device.async_init()
+        device.find_action("GetSubnetMask").url = ASYNC_SERVER_ADDR
+        mock_resp["text"] = TEST_DEVICE_AUTH
+        await device("GetSubnetMask", http_headers=call_headers)
+        self.assertEqual(mock_req["headers"]["test"], "call")
+        await device.session.close()
+
     def test_device_props(self):
         """
         `Device` instance should contain the properties from the XML.
         """
-        server = upnp.Device("http://127.0.0.1:%s/upnp/IGD.xml" % self.httpd_port)
+        server = upnp.Device(self.xml_resource)
+        self.assertEqual(
+            server.device_type, "urn:schemas-upnp-org:device:InternetGatewayDevice:1"
+        )
+        self.assertEqual(server.friendly_name, "SpeedTouch 5x6 (0320FJ2PZ)")
+        self.assertEqual(server.manufacturer, "Pannaway")
+        self.assertEqual(server.model_description, "DSL Internet Gateway Device")
+        self.assertEqual(server.model_name, "Pannaway")
+        self.assertEqual(server.model_number, "RG-210")
+        self.assertEqual(server.serial_number, "0320FJ2PZ")
+
+    @async_test
+    async def test_device_props_async(self):
+        """
+        `Device` instance should contain the properties from the XML.
+        """
+        server = upnp.Device(self.xml_resource, use_async=True)
+        await server.async_init()
+        await server.session.close()
         self.assertEqual(
             server.device_type, "urn:schemas-upnp-org:device:InternetGatewayDevice:1"
         )
@@ -274,6 +351,20 @@ class TestUPnPClientWithServer(unittest.TestCase):
             "http://127.0.0.1:%s/upnp/DOESNOTEXIST.xml" % self.httpd_port,
         )
 
+    @async_test
+    async def test_device_nonexists_async(self):
+        """
+        Should return `ClientResponseError` if the XML is not found on the server.
+        """
+        server = upnp.Device(
+            "http://127.0.0.1:%s/upnp/DOESNOTEXIST.xml" % self.httpd_port,
+            use_async=True
+        )
+        with self.assertRaises(aiohttp.client_exceptions.ClientResponseError):
+            await server.async_init()
+        await server.session.close()
+
+    @add_async_test
     def test_services(self):
         """
         All of the services from the XML should be present in the server services.
@@ -283,20 +374,34 @@ class TestUPnPClientWithServer(unittest.TestCase):
         self.assertIn("urn:upnp-org:serviceId:lanhcm", service_ids)
         self.assertIn("urn:upnp-org:serviceId:wancic", service_ids)
 
+    @add_async_test
     def test_actions(self):
         """
-        Action names should be present in the list of server actions.
+        Action names should be present in the list of device actions.
         """
         action_names = set()
-        for service in self.server.services:
-            for action in service.actions:
-                action_names.add(action.name)
-
+        for action in self.async_server.actions:
+            action_names.add(action.name)
         self.assertIn("SetDefaultConnectionService", action_names)
         self.assertIn("GetCommonLinkProperties", action_names)
         self.assertIn("GetDNSServers", action_names)
         self.assertIn("GetDHCPRelay", action_names)
 
+    @add_async_test
+    def test_service_actions(self):
+        """
+        Action names should be present in the list of service actions.
+        """
+        action_names = set()
+        for service in self.server.services:
+            for action in service.actions:
+                action_names.add(action.name)
+        self.assertIn("SetDefaultConnectionService", action_names)
+        self.assertIn("GetCommonLinkProperties", action_names)
+        self.assertIn("GetDNSServers", action_names)
+        self.assertIn("GetDHCPRelay", action_names)
+
+    @add_async_test
     def test_findaction_server(self):
         """
         Should find and return the correct action.
@@ -305,6 +410,7 @@ class TestUPnPClientWithServer(unittest.TestCase):
         self.assertIsInstance(action, upnp.Action)
         self.assertEqual(action.name, "GetSubnetMask")
 
+    @add_async_test
     def test_findaction_server_nonexists(self):
         """
         Should return None if no action is found with the given name.
@@ -312,11 +418,11 @@ class TestUPnPClientWithServer(unittest.TestCase):
         action = self.server.find_action("GetNoneExistingAction")
         self.assertEqual(action, None)
 
+    @add_async_test
     def test_findaction_service_nonexists(self):
         """
         Should return None if no action is found with the given name.
         """
-        service = self.server.services[0]
         action = self.server.find_action("GetNoneExistingAction")
         self.assertEqual(action, None)
 
@@ -326,17 +432,19 @@ class TestUPnPClientWithServer(unittest.TestCase):
         Should be able to call the server with the name of an action.
         """
         ret = mock.Mock()
-        ret.content = """
-        <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
-           <s:Body>
-              <u:GetSubnetMaskResponse xmlns:u="urn:schemas-upnp-org:service:LANHostConfigManagement:1">
-                 <NewSubnetMask>255.255.255.0</NewSubnetMask>
-              </u:GetSubnetMaskResponse>
-           </s:Body>
-        </s:Envelope>
-        """
+        ret.content = TEST_DEVICE_AUTH
         mock_post.return_value = ret
         ret = self.server("GetSubnetMask")
+        self.assertEqual(ret, dict(NewSubnetMask="255.255.255.0"))
+
+    @async_test
+    async def test_callaction_server_async(self):
+        """
+        Should be able to call the server with the name of an action.
+        """
+        mock_resp["text"] = TEST_DEVICE_AUTH
+        self.async_server.find_action("GetSubnetMask").url = ASYNC_SERVER_ADDR
+        ret = await self.async_server("GetSubnetMask")
         self.assertEqual(ret, dict(NewSubnetMask="255.255.255.0"))
 
     @mock.patch("requests.post")
@@ -345,20 +453,25 @@ class TestUPnPClientWithServer(unittest.TestCase):
         Should be able to call an action with no params and get the results.
         """
         ret = mock.Mock()
-        ret.content = """
-        <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
-           <s:Body>
-              <u:GetAddressRangeResponse xmlns:u="urn:schemas-upnp-org:service:LANHostConfigManagement:1">
-                 <NewMinAddress>10.0.0.2</NewMinAddress>
-                 <NewMaxAddress>10.0.0.254</NewMaxAddress>
-              </u:GetAddressRangeResponse>
-           </s:Body>
-        </s:Envelope>
-        """
+        ret.content = TEST_CALLACTION_NOPARAM
         mock_post.return_value = ret
         action = self.server.find_action("GetAddressRange")
         self.assertIsInstance(action, upnp.Action)
         response = action()
+        self.assertIsInstance(response, dict)
+        self.assertEqual(response["NewMinAddress"], "10.0.0.2")
+        self.assertEqual(response["NewMaxAddress"], "10.0.0.254")
+
+    @async_test
+    async def test_callaction_noparam_async(self):
+        """
+        Should be able to call an action with no params and get the results.
+        """
+        mock_resp["text"] = TEST_CALLACTION_NOPARAM
+        action = self.async_server.find_action("GetAddressRange")
+        action.url = ASYNC_SERVER_ADDR
+        self.assertIsInstance(action, upnp.Action)
+        response = await action()
         self.assertIsInstance(response, dict)
         self.assertEqual(response["NewMinAddress"], "10.0.0.2")
         self.assertEqual(response["NewMaxAddress"], "10.0.0.254")
@@ -369,20 +482,23 @@ class TestUPnPClientWithServer(unittest.TestCase):
         Should be able to call an action with parameters and get the results.
         """
         ret = mock.Mock()
-        ret.content = """
-        <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
-           <s:Body>
-              <u:GetGenericPortMappingEntryResponse xmlns:u="urn:schemas-upnp-org:service:Layer3Forwarding:1">
-                 <NewInternalClient>10.0.0.1</NewInternalClient>
-                 <NewExternalPort>51773</NewExternalPort>
-                 <NewEnabled>true</NewEnabled>
-              </u:GetGenericPortMappingEntryResponse>
-           </s:Body>
-        </s:Envelope>
-        """
+        ret.content = TEST_CALLACTION_PARAM
         mock_post.return_value = ret
         action = self.server.find_action("GetGenericPortMappingEntry")
         response = action(NewPortMappingIndex=0)
+        self.assertEqual(response["NewInternalClient"], "10.0.0.1")
+        self.assertEqual(response["NewExternalPort"], 51773)
+        self.assertEqual(response["NewEnabled"], True)
+
+    @async_test
+    async def test_callaction_param_async(self):
+        """
+        Should be able to call an action with parameters and get the results.
+        """
+        mock_resp["text"] = TEST_CALLACTION_PARAM
+        action = self.async_server.find_action("GetGenericPortMappingEntry")
+        action.url = ASYNC_SERVER_ADDR
+        response = await action(NewPortMappingIndex=0)
         self.assertEqual(response["NewInternalClient"], "10.0.0.1")
         self.assertEqual(response["NewExternalPort"], 51773)
         self.assertEqual(response["NewEnabled"], True)
@@ -394,6 +510,15 @@ class TestUPnPClientWithServer(unittest.TestCase):
         action = self.server.find_action("GetGenericPortMappingEntry")
         self.assertRaises(upnp.UPNPError, action)
 
+    @async_test
+    async def test_callaction_param_missing_async(self):
+        """
+        Calling an action without its parameters should raise a UPNPError.
+        """
+        action = self.async_server.find_action("GetGenericPortMappingEntry")
+        with self.assertRaises(upnp.UPNPError):
+            await action()
+
     def test_callaction_param_invalid_ui2(self):
         """
         Calling an action with an invalid data type should raise a UPNPError.
@@ -401,26 +526,39 @@ class TestUPnPClientWithServer(unittest.TestCase):
         action = self.server.find_action("GetGenericPortMappingEntry")
         self.assertRaises(upnp.ValidationError, action, NewPortMappingIndex="ZERO")
 
+    @async_test
+    async def test_callaction_param_invalid_ui2_async(self):
+        """
+        Calling an action with an invalid data type should raise a UPNPError.
+        """
+        action = self.server.find_action("GetGenericPortMappingEntry")
+        with self.assertRaises(upnp.ValidationError):
+            await action(NewPortMappingIndex="ZERO")
+
     @mock.patch("requests.post")
     def test_callaction_param_mashal_out(self, mock_post):
         """
         Values should be marshalled into the appropriate Python data types.
         """
         ret = mock.Mock()
-        ret.content = """
-        <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
-           <s:Body>
-              <u:GetGenericPortMappingEntryResponse xmlns:u="urn:schemas-upnp-org:service:Layer3Forwarding:1">
-                 <NewInternalClient>10.0.0.1</NewInternalClient>
-                 <NewExternalPort>51773</NewExternalPort>
-                 <NewEnabled>true</NewEnabled>
-              </u:GetGenericPortMappingEntryResponse>
-           </s:Body>
-        </s:Envelope>
-        """
+        ret.content = TEST_CALLACTION_PARAM_MASHAL_OUT_ASYNC
         mock_post.return_value = ret
         action = self.server.find_action("GetGenericPortMappingEntry")
         response = action(NewPortMappingIndex=0)
+
+        self.assertIsInstance(response["NewInternalClient"], basestring)
+        self.assertIsInstance(response["NewExternalPort"], int)
+        self.assertIsInstance(response["NewEnabled"], bool)
+
+    @async_test
+    async def test_callaction_param_mashal_out_async(self):
+        """
+        Values should be marshalled into the appropriate Python data types.
+        """
+        mock_resp["text"] = TEST_CALLACTION_PARAM_MASHAL_OUT_ASYNC
+        action = self.async_server.find_action("GetGenericPortMappingEntry")
+        action.url = ASYNC_SERVER_ADDR
+        response = await action(NewPortMappingIndex=0)
 
         self.assertIsInstance(response["NewInternalClient"], basestring)
         self.assertIsInstance(response["NewExternalPort"], int)
@@ -437,6 +575,18 @@ class TestUPnPClientWithServer(unittest.TestCase):
         except upnp.InvalidActionException:
             pass
 
+    @async_test
+    async def test_callaction_nonexisting_async(self):
+        """
+        When a non-existent action is called, an InvalidActionException should be raised.
+        """
+        service = self.server.services[0]
+        try:
+            await service("NoSuchFunction")
+            self.fail("An InvalidActionException should be raised.")
+        except upnp.InvalidActionException:
+            pass
+
     @mock.patch("requests.post")
     def test_callaction_upnperror(self, mock_post):
         """
@@ -444,26 +594,27 @@ class TestUPnPClientWithServer(unittest.TestCase):
         """
         exc = requests.exceptions.HTTPError(500)
         exc.response = mock.Mock()
-        exc.response.content = """
-        <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
-          <s:Body>
-            <s:Fault>
-              <faultcode>s:Client</faultcode>
-              <faultstring>UPnPError</faultstring>
-              <detail>
-                <UPnPError xmlns="urn:schemas-upnp-org:control-1-0">
-                  <errorCode>401</errorCode>
-                  <errorDescription>Invalid Action</errorDescription>
-                </UPnPError>
-              </detail>
-            </s:Fault>
-          </s:Body>
-        </s:Envelope>
-        """.strip()
+        exc.response.content = TEST_CALLACTION_UPNPERROR
         mock_post.side_effect = exc
         action = self.server.find_action("SetDefaultConnectionService")
         try:
             action(NewDefaultConnectionService="foo")
+        except upnp.soap.SOAPError as exc:
+            code, desc = exc.args
+            self.assertEqual(code, 401)
+            self.assertEqual(desc, "Invalid Action")
+
+    @async_test
+    async def test_callaction_upnperror_async(self):
+        """
+        UPNPErrors should be raised with the correct error code and description.
+        """
+        mock_resp["status"] = 500
+        mock_resp["text"] = TEST_CALLACTION_UPNPERROR
+        action = self.async_server.find_action("SetDefaultConnectionService")
+        action.url = ASYNC_SERVER_ADDR
+        try:
+            await action(NewDefaultConnectionService="foo")
         except upnp.soap.SOAPError as exc:
             code, desc = exc.args
             self.assertEqual(code, 401)
@@ -490,6 +641,25 @@ class TestUPnPClientWithServer(unittest.TestCase):
         self.assertEqual(req.headers["HOST"], "127.0.0.1:%s" % self.httpd_port)
         self.assertEqual(req.headers["TIMEOUT"], "Second-123")
 
+    @async_test
+    async def test_subscribe_async(self):
+        """
+        Should perform a well formed HTTP SUBSCRIBE request.
+        """
+        cb_url = "http://127.0.0.1/"
+        self.async_server.layer3f._url_base = ASYNC_SERVER_ADDR
+        try:
+            await self.async_server.layer3f.async_subscribe(cb_url, timeout=123)
+        except Exception:
+            pass
+        req = mock_req["request"]
+        self.assertEqual(req.method, "SUBSCRIBE")
+        self.assertEqual(req.get("body"), None)
+        self.assertEqual(req.headers["NT"], "upnp:event")
+        self.assertEqual(req.headers["CALLBACK"], "<%s>" % cb_url)
+        self.assertEqual(req.headers["HOST"], ASYNC_HOST)
+        self.assertEqual(req.headers["TIMEOUT"], "Second-123")
+
     @mock.patch("requests.Session.send", side_effect=EndPrematurelyException)
     def test_renew_subscription(self, mock_send):
         """
@@ -510,6 +680,25 @@ class TestUPnPClientWithServer(unittest.TestCase):
         self.assertEqual(req.headers["SID"], sid)
         self.assertEqual(req.headers["TIMEOUT"], "Second-123")
 
+    @async_test
+    async def test_renew_subscription_async(self):
+        """
+        Should perform a well formed HTTP SUBSCRIBE request on sub renewal.
+        """
+        sid = "abcdef"
+        self.async_server.layer3f._url_base = ASYNC_SERVER_ADDR
+        try:
+            await self.async_server.layer3f.async_renew_subscription(sid, timeout=123)
+        except Exception:
+            pass
+
+        req = mock_req["request"]
+        self.assertEqual(req.method, "SUBSCRIBE")
+        self.assertEqual(req.get("body"), None)
+        self.assertEqual(req.headers["HOST"], ASYNC_HOST)
+        self.assertEqual(req.headers["SID"], sid)
+        self.assertEqual(req.headers["TIMEOUT"], "Second-123")
+
     @mock.patch("requests.Session.send", side_effect=EndPrematurelyException)
     def test_cancel_subscription(self, mock_send):
         """
@@ -527,6 +716,22 @@ class TestUPnPClientWithServer(unittest.TestCase):
         )
         self.assertEqual(req.body, None)
         self.assertEqual(req.headers["HOST"], "127.0.0.1:%s" % self.httpd_port)
+        self.assertEqual(req.headers["SID"], sid)
+
+    @async_test
+    async def test_cancel_subscription_async(self):
+        """
+        Should perform a well formed HTTP UNSUBSCRIBE request on sub cancellation.
+        """
+        sid = "abcdef"
+        self.async_server.layer3f._url_base = ASYNC_SERVER_ADDR
+        try:
+            await self.async_server.layer3f.async_cancel_subscription(sid)
+        except Exception:
+            pass
+        req = mock_req["request"]
+        self.assertEqual(req.get("body"), None)
+        self.assertEqual(req.headers["HOST"], ASYNC_HOST)
         self.assertEqual(req.headers["SID"], sid)
 
     @mock.patch("requests.Session.send", side_effect=EndPrematurelyException)
@@ -559,391 +764,21 @@ class TestUPnPClientWithServer(unittest.TestCase):
         ]
         self.assertEqual("".join(args), alphabet)
 
+    @add_async_test
     def test_args_order_read_ok(self):
         """
         Make sure that the arguments in the XML are read in order by lxml.
         """
-        xpath = 's:actionList/s:action/s:name[text()="InArgsTest"]/../s:argumentList/s:argument/s:name'
+        xpath = (
+            's:actionList/s:action/s:name[text()="InArgsTest"]'
+            '/../s:argumentList/s:argument/s:name'
+        )
         xml = self.server.service_map["lanhcm"].scpd_xml
         args = xml.xpath(xpath, namespaces={"s": xml.nsmap[None]})
         self.assertEqual("".join(x.text for x in args), "ABCDEFGHIJKLMNOPQRSTUVWXYZ")
 
+    # SOAP module tests - see upnpclient/soap.py ---------------------------------------------------
 
-class TestUPnPClient(unittest.TestCase):
-    @mock.patch("upnpclient.ssdp.Device", return_value="test string")
-    @mock.patch("upnpclient.ssdp.scan")
-    def test_discover(self, mock_scan, mock_server):
-        """
-        discover() should call netdisco's scan function and return a list of unique servers.
-        """
-        url = "http://www.example.com"
-        entry = mock.Mock()
-        entry.location = url
-        mock_scan.return_value = [entry, entry]
-        ret = upnp.discover()
-        mock_scan.assert_called()
-        mock_server.assert_called_with(url)
-        self.assertEqual(ret, ["test string"])
-
-    @mock.patch("upnpclient.ssdp.Device", side_effect=Exception)
-    @mock.patch("upnpclient.ssdp.scan")
-    def test_discover_exception(self, mock_scan, mock_server):
-        """
-        If unable to read a discovered server's root XML file, it should not appear in the list.
-        """
-        url = "http://www.example.com"
-        entry = mock.Mock()
-        entry.location = url
-        mock_scan.return_value = [entry]
-        ret = upnp.discover()
-        mock_scan.assert_called()
-        mock_server.assert_called_with(url)
-        self.assertEqual(ret, [])
-
-    def test_validate_date(self):
-        """
-        Should validate the 'date' type.
-        """
-        ret = upnp.Action.validate_arg("2017-08-11", dict(datatype="date"))
-        self.assertEqual(ret, (True, set()))
-
-    def test_validate_bad_date(self):
-        """
-        Bad 'date' type should fail validation.
-        """
-        valid, reasons = upnp.Action.validate_arg("2017-13-13", dict(datatype="date"))
-        print(reasons)
-        self.assertTrue(reasons)
-        self.assertFalse(valid)
-
-    def test_validate_date_with_time(self):
-        """
-        Should raise a ValidationError if a 'date' contains a time.
-        """
-        valid, reasons = upnp.Action.validate_arg(
-            "2017-13-13T12:34:56", dict(datatype="date")
-        )
-        print(reasons)
-        self.assertTrue(reasons)
-        self.assertFalse(valid)
-
-    def test_marshal_date(self):
-        """
-        Should parse a valid date into a `datetime.date` object.
-        """
-        marshalled, val = upnp.marshal.marshal_value("date", "2017-08-11")
-        self.assertTrue(marshalled)
-        self.assertIsInstance(val, datetime.date)
-        tests = dict(year=2017, month=8, day=11)
-        for key, value in tests.items():
-            self.assertEqual(getattr(val, key), value)
-
-    def test_marshal_datetime(self):
-        """
-        Should parse and marshal a 'dateTime' into a timezone naive `datetime.datetime`.
-        """
-        marshalled, val = upnp.marshal.marshal_value("dateTime", "2017-08-11T12:34:56")
-        self.assertTrue(marshalled)
-        self.assertIsInstance(val, datetime.datetime)
-        tests = dict(year=2017, month=8, day=11, hour=12, minute=34, second=56)
-        for key, value in tests.items():
-            self.assertEqual(getattr(val, key), value)
-        self.assertEqual(val.tzinfo, None)
-
-    def test_marshal_datetime_tz(self):
-        """
-        Should parse and marshal a 'dateTime.tz' into a timezone aware `datetime.datetime`.
-        """
-        marshalled, val = upnp.marshal.marshal_value(
-            "dateTime.tz", "2017-08-11T12:34:56+1:00"
-        )
-        self.assertTrue(marshalled)
-        self.assertIsInstance(val, datetime.datetime)
-        tests = dict(year=2017, month=8, day=11, hour=12, minute=34, second=56)
-        for key, value in tests.items():
-            self.assertEqual(getattr(val, key), value)
-        self.assertEqual(val.utcoffset(), datetime.timedelta(hours=1))
-
-    def test_validate_time_illegal_tz(self):
-        """
-        Should fail validation if 'time' contains a timezone.
-        """
-        valid, reasons = upnp.Action.validate_arg("12:34:56+1:00", dict(datatype="time"))
-        print(reasons)
-        self.assertTrue(reasons)
-        self.assertFalse(valid)
-
-    def test_marshal_time(self):
-        """
-        Should parse a 'time' into a timezone naive `datetime.time`.
-        """
-        marshalled, val = upnp.marshal.marshal_value("time", "12:34:56")
-        self.assertTrue(marshalled)
-        self.assertIsInstance(val, datetime.time)
-        tests = dict(hour=12, minute=34, second=56)
-        for key, value in tests.items():
-            self.assertEqual(getattr(val, key), value)
-        self.assertEqual(val.tzinfo, None)
-
-    def test_marshal_time_tz(self):
-        """
-        Should parse a 'time.tz' into a timezone aware `datetime.time`.
-        """
-        marshalled, val = upnp.marshal.marshal_value("time.tz", "12:34:56+1:00")
-        self.assertTrue(marshalled)
-        self.assertIsInstance(val, datetime.time)
-        tests = dict(hour=12, minute=34, second=56)
-        for key, value in tests.items():
-            self.assertEqual(getattr(val, key), value)
-        self.assertEqual(val.utcoffset(), datetime.timedelta(hours=1))
-
-    def test_marshal_bool(self):
-        """
-        Should parse a 'boolean' into a `bool`.
-        """
-        valid_true = ("1", "true", "TRUE", "True", "yes", "YES", "Yes")
-        valid_false = ("0", "false", "FALSE", "False", "no", "NO", "No")
-        tests = list(zip(valid_true, [True] * len(valid_true))) + list(
-            zip(valid_false, [False] * len(valid_false))
-        )
-        for item, test in tests:
-            marshalled, val = upnp.marshal.marshal_value("boolean", item)
-            self.assertTrue(marshalled)
-            self.assertEqual(val, test)
-
-    def test_validate_bad_bool(self):
-        """
-        Should raise a ValidationError if an invalid 'boolean' is provided.
-        """
-        valid, reasons = upnp.Action.validate_arg("2", dict(datatype="boolean"))
-        print(reasons)
-        self.assertTrue(reasons)
-        self.assertFalse(valid)
-
-    def test_validate_base64(self):
-        """
-        Should validate a 'bin.base64' value.
-        """
-        bstring = "Hello, World!".encode("utf8")
-        encoded = base64.b64encode(bstring)
-        valid, reasons = upnp.Action.validate_arg(encoded, dict(datatype="bin.base64"))
-        print(reasons)
-        self.assertFalse(reasons)
-        self.assertTrue(valid)
-
-    def test_marshal_base64(self):
-        """
-        Should simply leave the base64 string as it is.
-        """
-        bstring = "Hello, World!".encode("utf8")
-        encoded = base64.b64encode(bstring)
-        marshalled, val = upnp.marshal.marshal_value("bin.base64", encoded)
-        self.assertTrue(marshalled)
-        self.assertEqual(val, encoded)
-
-    def test_validate_hex(self):
-        """
-        Should validate a 'bin.hex' value.
-        """
-        bstring = "Hello, World!".encode("ascii")
-        valid, reasons = upnp.Action.validate_arg(
-            binascii.hexlify(bstring), dict(datatype="bin.hex")
-        )
-        print(reasons)
-        self.assertFalse(reasons)
-        self.assertTrue(valid)
-
-    def test_marshal_hex(self):
-        """
-        Should simply leave the hex string as it is.
-        """
-        bstring = "Hello, World!".encode("ascii")
-        encoded = binascii.hexlify(bstring)
-        marshalled, val = upnp.marshal.marshal_value("bin.hex", encoded)
-        self.assertTrue(marshalled)
-        self.assertEqual(val, encoded)
-
-    def test_validate_uri(self):
-        """
-        Should validate a 'uri' value.
-        """
-        uri = "https://media.giphy.com/media/22kxQ12cxyEww/giphy.gif?something=variable"
-        valid, reasons = upnp.Action.validate_arg(uri, dict(datatype="uri"))
-        print(reasons)
-        self.assertFalse(reasons)
-        self.assertTrue(valid)
-
-    def test_marshal_uri(self):
-        """
-        Should parse a 'uri' value into a `ParseResult`.
-        """
-        uri = "https://media.giphy.com/media/22kxQ12cxyEww/giphy.gif?something=variable"
-        marshalled, val = upnp.marshal.marshal_value("uri", uri)
-        self.assertTrue(marshalled)
-        self.assertIsInstance(val, ParseResult)
-
-    def test_validate_uuid(self):
-        """
-        Should validate a 'uuid' value.
-        """
-        uuid = "bec6d681-a6af-4e7d-8b31-bcb78018c814"
-        valid, reasons = upnp.Action.validate_arg(uuid, dict(datatype="uuid"))
-        print(reasons)
-        self.assertFalse(reasons)
-        self.assertTrue(valid)
-
-    def test_validate_bad_uuid(self):
-        """
-        Should reject badly formatted 'uuid' values.
-        """
-        uuid = "bec-6d681a6af-4e7d-8b31-bcb78018c814"
-        valid, reasons = upnp.Action.validate_arg(uuid, dict(datatype="uuid"))
-        self.assertTrue(reasons)
-        self.assertFalse(valid)
-
-    def test_marshal_uuid(self):
-        """
-        Should parse a 'uuid' into a `uuid.UUID`.
-        """
-        uuid = "bec6d681-a6af-4e7d-8b31-bcb78018c814"
-        marshalled, val = upnp.marshal.marshal_value("uuid", uuid)
-        self.assertTrue(marshalled)
-        self.assertIsInstance(val, UUID)
-
-    def test_validate_subscription_response(self):
-        """
-        Should validate the sub response and return sid and timeout.
-        """
-        sid = "abcdef"
-        timeout = 123
-        resp = mock.Mock()
-        resp.headers = dict(SID=sid, Timeout="Second-%s" % timeout)
-        rsid, rtimeout = upnp.Service.validate_subscription_response(resp)
-        self.assertEqual(rsid, sid)
-        self.assertEqual(rtimeout, timeout)
-
-    def test_validate_subscription_response_caps(self):
-        """
-        Should validate the sub response and return sid and timeout regardless of capitalisation.
-        """
-        sid = "abcdef"
-        timeout = 123
-        resp = mock.Mock()
-        resp.headers = dict(sid=sid, TIMEOUT="SeCoNd-%s" % timeout)
-        rsid, rtimeout = upnp.Service.validate_subscription_response(resp)
-        self.assertEqual(rsid, sid)
-        self.assertEqual(rtimeout, timeout)
-
-    def test_validate_subscription_response_infinite(self):
-        """
-        Should validate the sub response and return None as the timeout.
-        """
-        sid = "abcdef"
-        timeout = "infinite"
-        resp = mock.Mock()
-        resp.headers = dict(SID=sid, Timeout="Second-%s" % timeout)
-        rsid, rtimeout = upnp.Service.validate_subscription_response(resp)
-        self.assertEqual(rsid, sid)
-        self.assertEqual(rtimeout, None)
-
-    def test_validate_subscription_response_no_timeout(self):
-        """
-        Should raise UnexpectedResponse if timeout is missing.
-        """
-        resp = mock.Mock()
-        resp.headers = dict(SID="abcdef")
-        self.assertRaises(
-            upnp.UnexpectedResponse, upnp.Service.validate_subscription_response, resp
-        )
-
-    def test_validate_subscription_response_no_sid(self):
-        """
-        Should raise UnexpectedResponse if sid is missing.
-        """
-        resp = mock.Mock()
-        resp.headers = dict(Timeout="Second-123")
-        self.assertRaises(
-            upnp.UnexpectedResponse, upnp.Service.validate_subscription_response, resp
-        )
-
-    def test_validate_subscription_response_bad_timeout(self):
-        """
-        Should raise UnexpectedResponse if timeout is in the wrong format.
-        """
-        resp = mock.Mock()
-        resp.headers = dict(SID="abcdef", Timeout="123")
-        self.assertRaises(
-            upnp.UnexpectedResponse, upnp.Service.validate_subscription_response, resp
-        )
-
-    def test_validate_subscription_response_bad_timeout2(self):
-        """
-        Should raise UnexpectedResponse if timeout is not an int/infinite.
-        """
-        resp = mock.Mock()
-        resp.headers = dict(SID="abcdef", Timeout="Second-abc")
-        self.assertRaises(
-            upnp.UnexpectedResponse, upnp.Service.validate_subscription_response, resp
-        )
-
-    def test_validate_subscription_renewal_response(self):
-        """
-        Should validate the sub renewal response and return the timeout.
-        """
-        timeout = 123
-        resp = mock.Mock()
-        resp.headers = dict(Timeout="Second-%s" % timeout)
-        rtimeout = upnp.Service.validate_subscription_renewal_response(resp)
-        self.assertEqual(rtimeout, timeout)
-
-    def test_validate_subscription_renewal_response_infinite(self):
-        """
-        Should validate the sub renewal response and return None as the timeout.
-        """
-        timeout = "infinite"
-        resp = mock.Mock()
-        resp.headers = dict(Timeout="Second-%s" % timeout)
-        rtimeout = upnp.Service.validate_subscription_renewal_response(resp)
-        self.assertEqual(rtimeout, None)
-
-    def test_validate_subscription_renewal_response_no_timeout(self):
-        """
-        Should raise UnexpectedResponse if timeout is missing.
-        """
-        resp = mock.Mock()
-        resp.headers = dict()
-        self.assertRaises(
-            upnp.UnexpectedResponse,
-            upnp.Service.validate_subscription_renewal_response,
-            resp,
-        )
-
-    def test_validate_subscription_renewal_response_bad_timeout(self):
-        """
-        Should raise UnexpectedResponse if timeout is in the wrong format.
-        """
-        resp = mock.Mock()
-        resp.headers = dict(Timeout="123")
-        self.assertRaises(
-            upnp.UnexpectedResponse,
-            upnp.Service.validate_subscription_renewal_response,
-            resp,
-        )
-
-    def test_validate_subscription_renewal_response_bad_timeout2(self):
-        """
-        Should raise UnexpectedResponse if timeout is not an int/infinite.
-        """
-        resp = mock.Mock()
-        resp.headers = dict(Timeout="Second-abc")
-        self.assertRaises(
-            upnp.UnexpectedResponse,
-            upnp.Service.validate_subscription_renewal_response,
-            resp,
-        )
-
-
-class TestSOAP(unittest.TestCase):
     @mock.patch("requests.post", side_effect=EndPrematurelyException)
     def test_call(self, mock_post):
         url = "http://www.example.com"
@@ -954,6 +789,14 @@ class TestSOAP(unittest.TestCase):
         call_url, body = args
         self.assertEqual(url, call_url)
         etree.fromstring(body)
+
+    @async_test
+    async def test_call_async(self):
+        url = ASYNC_SERVER_ADDR
+        soap = upnp.soap.SOAP(url, "test", session=self.session)
+        with self.assertRaises(Exception):
+            await soap.async_call("TestAction")
+        self.assertEqual(ASYNC_HOST, mock_req["headers"]["Host"])
 
     @mock.patch("requests.post", side_effect=EndPrematurelyException)
     def test_call_with_auth(self, mock_post):
@@ -971,6 +814,17 @@ class TestSOAP(unittest.TestCase):
         self.assertIn("auth", kwargs)
         self.assertEqual(kwargs["auth"], auth)
 
+    @async_test
+    async def test_call_with_auth_async(self):
+        mock_resp["status"] = 400
+        auth = ("myuser", "mypassword")
+        soap = upnp.soap.SOAP(ASYNC_SERVER_ADDR, "test", session=self.session)
+        with self.assertRaises(aiohttp.client_exceptions.ClientResponseError):
+            await soap.async_call("TestAction", http_auth=auth)
+        basic_auth_string = f"{auth[0]}:{auth[1]}"
+        b64 = b64encode(basic_auth_string.encode("utf-8")).decode()
+        self.assertEqual("Basic %s" % b64, mock_req["headers"]["Authorization"])
+
     @mock.patch("requests.post")
     def test_non_xml_error(self, mock_post):
         exc = requests.exceptions.HTTPError()
@@ -980,106 +834,60 @@ class TestSOAP(unittest.TestCase):
         soap = upnp.soap.SOAP("http://www.example.com", "test")
         self.assertRaises(requests.exceptions.HTTPError, soap.call, "TestAction")
 
+    @async_test
+    async def test_non_xml_error_async(self):
+        mock_resp["status"] = 400
+        mock_resp["text"] = "this is not valid xml"
+        soap = upnp.soap.SOAP(ASYNC_SERVER_ADDR, "test", session=self.session)
+        with self.assertRaises(aiohttp.client_exceptions.ClientResponseError):
+            await soap.async_call("TestAction")
+
     @mock.patch("requests.post")
     def test_missing_error_code_element(self, mock_post):
         exc = requests.exceptions.HTTPError()
         exc.response = mock.Mock()
-        exc.response.content = """
-        <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
-          <s:Body>
-            <s:Fault>
-              <faultcode>s:Client</faultcode>
-              <faultstring>UPnPError</faultstring>
-              <detail>
-                <UPnPError xmlns="urn:schemas-upnp-org:control-1-0">
-                  <errorDescription>Invalid Action</errorDescription>
-                </UPnPError>
-              </detail>
-            </s:Fault>
-          </s:Body>
-        </s:Envelope>
-        """.strip()
+        exc.response.content = TEST_MISSING_ERROR_CODE_ELEMENT
         mock_post.side_effect = exc
         soap = upnp.soap.SOAP("http://www.example.com", "test")
         self.assertRaises(upnp.soap.SOAPProtocolError, soap.call, "TestAction")
+
+    @async_test
+    async def test_missing_error_code_element_async(self):
+        mock_resp["status"] = 400
+        mock_resp["text"] = TEST_MISSING_ERROR_CODE_ELEMENT
+        soap = upnp.soap.SOAP(ASYNC_SERVER_ADDR, "test", session=self.session)
+        with self.assertRaises(upnp.soap.SOAPProtocolError):
+            await soap.async_call("TestAction")
 
     @mock.patch("requests.post")
     def test_missing_error_description_element(self, mock_post):
         exc = requests.exceptions.HTTPError()
         exc.response = mock.Mock()
-        exc.response.content = """
-        <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
-          <s:Body>
-            <s:Fault>
-              <faultcode>s:Client</faultcode>
-              <faultstring>UPnPError</faultstring>
-              <detail>
-                <UPnPError xmlns="urn:schemas-upnp-org:control-1-0">
-                  <errorCode>401</errorCode>
-                </UPnPError>
-              </detail>
-            </s:Fault>
-          </s:Body>
-        </s:Envelope>
-        """.strip()
+        exc.response.content = TEST_MISSING_ERROR_DESCRIPTION_ELEMENT
         mock_post.side_effect = exc
         soap = upnp.soap.SOAP("http://www.example.com", "test")
         self.assertRaises(upnp.soap.SOAPProtocolError, soap.call, "TestAction")
 
+    @async_test
+    async def test_missing_error_description_element_async(self):
+        mock_resp["status"] = 400
+        mock_resp["text"] = TEST_MISSING_ERROR_DESCRIPTION_ELEMENT
+        soap = upnp.soap.SOAP(ASYNC_SERVER_ADDR, "test", session=self.session)
+        with self.assertRaises(upnp.soap.SOAPProtocolError):
+            await soap.async_call("TestAction")
+
     @mock.patch("requests.post")
     def test_missing_response_element(self, mock_post):
         ret = mock.Mock()
-        ret.content = """
-        <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
-           <s:Body>
-              <u:SomeOtherElement xmlns:u="urn:schemas-upnp-org:service:Layer3Forwarding:1">
-                 <NewEnabled>true</NewEnabled>
-              </u:SomeOtherElement>
-           </s:Body>
-        </s:Envelope>
-        """
+        ret.content = TEST_MISSING_RESPONSE_ELEMENT
         mock_post.return_value = ret
         soap = upnp.soap.SOAP("http://www.example.com", "test")
         self.assertRaises(upnp.soap.SOAPProtocolError, soap.call, "TestAction")
 
-
-class TestErrors(unittest.TestCase):
-    desc = upnp.errors.ERR_CODE_DESCRIPTIONS
-
-    def test_existing_err(self):
-        for key, value in self.desc._descriptions.items():
-            self.assertEqual(self.desc[key], value)
-
-    def test_non_integer(self):
-        try:
-            self.desc["a string"]
-            raise Exception("Should have raised KeyError.")
-        except KeyError as exc:
-            self.assertEqual(str(exc), "\"'key' must be an integer\"")
-
-    def test_reserved(self):
-        for i in range(606, 612 + 1):  # 606-612
-            self.assertEqual(
-                self.desc[i], "These ErrorCodes are reserved for UPnP DeviceSecurity."
-            )
-
-    def test_common_action(self):
-        for i in range(613, 699 + 1):
-            self.assertEqual(
-                self.desc[i],
-                "Common action errors. Defined by UPnP Forum Technical Committee.",
-            )
-
-    def test_action_specific_committee(self):
-        for i in range(700, 799 + 1):
-            self.assertEqual(
-                self.desc[i],
-                "Action-specific errors defined by UPnP Forum working committee.",
-            )
-
-    def test_action_specific_vendor(self):
-        for i in range(800, 899 + 1):
-            self.assertEqual(
-                self.desc[i],
-                "Action-specific errors for non-standard actions. Defined by UPnP vendor.",
-            )
+    @async_test
+    async def test_missing_response_element_async(self):
+        mock_resp["status"] = 400
+        mock_resp["text"] = TEST_MISSING_RESPONSE_ELEMENT
+        soap = upnp.soap.SOAP(ASYNC_SERVER_ADDR, "test", session=self.session)
+        with self.assertRaises(upnp.soap.SOAPProtocolError):
+            await soap.async_call("TestAction")

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,7 @@ commands =
 commands =
     poetry install -v
     poetry run flake8 upnpclient
+    poetry run flake8 tests --exclude=const.py
 
 [testenv:coverage]
 commands =

--- a/upnpclient/soap.py
+++ b/upnpclient/soap.py
@@ -26,13 +26,15 @@ class SOAP(object):
     This class defines a simple SOAP client.
     """
 
-    def __init__(self, url, service_type):
+    def __init__(self, url, service_type, session=None, **kwargs):
         self.url = url
         self.service_type = service_type
+        self.session = session
         # FIXME: Use urlparse for this:
         self._host = self.url.split("//", 1)[1].split("/", 1)[
             0
         ]  # Get hostname portion of url
+        self._arg_in = kwargs
         self._log = _getLogger("SOAP")
 
     def _extract_upnperror(self, err_xml):
@@ -78,13 +80,11 @@ class SOAP(object):
         xml_str = re.sub(r"<\?xml.*?\?>", "", xml_str, flags=re.I)
         return xml_declaration + xml_str
 
-    def call(self, action_name, arg_in=None, http_auth=None, http_headers=None):
+    def _create_request(self, action_name, http_headers=None):
         """
-        Construct the XML and make the call to the device. Parse the response values into a dict.
+        Create and return the request headers.
         """
-        if arg_in is None:
-            arg_in = {}
-
+        arg_in = self._arg_in or {}
         soap_env = "{%s}" % NS_SOAP_ENV
         m = "{%s}" % self.service_type
 
@@ -102,22 +102,13 @@ class SOAP(object):
             "Content-Length": str(len(body)),
         }
         headers.update(http_headers or {})
+        return (headers, body)
 
-        try:
-            resp = requests.post(
-                self.url, body, headers=headers, timeout=SOAP_TIMEOUT, auth=http_auth
-            )
-            resp.raise_for_status()
-        except requests.exceptions.HTTPError as exc:
-            # If the body of the error response contains XML then it should be a UPnP error,
-            # otherwise reraise the HTTPError.
-            try:
-                err_xml = etree.fromstring(exc.response.content)
-            except etree.XMLSyntaxError:
-                raise exc
-            raise SOAPError(*self._extract_upnperror(err_xml))
-
-        xml_str = resp.content.strip()
+    def _parse_response(self, action_name, data):
+        """
+        Parse XML data into a dict and return.
+        """
+        xml_str = data.strip()
         try:
             xml = etree.fromstring(xml_str)
         except etree.XMLSyntaxError:
@@ -149,5 +140,46 @@ class SOAP(object):
                 ret[arg.tag] = b"\n".join(etree.tostring(x) for x in children)
             else:
                 ret[arg.tag] = arg.text
-
         return ret
+
+    def call(self, action_name, http_auth=None, http_headers=None):
+        """
+        Construct the XML and make the call to the device. Parse the response values into a dict.
+        """
+        headers, body = self._create_request(action_name, http_headers=http_headers)
+
+        try:
+            resp = requests.post(
+                self.url, body, headers=headers, timeout=SOAP_TIMEOUT, auth=http_auth
+            )
+            resp.raise_for_status()
+        except requests.exceptions.HTTPError as exc:
+            # If the body of the error response contains XML then it should be a UPnP error,
+            # otherwise reraise the HTTPError.
+            try:
+                err_xml = etree.fromstring(exc.response.content)
+            except etree.XMLSyntaxError:
+                raise exc
+            raise SOAPError(*self._extract_upnperror(err_xml))
+        return self._parse_response(action_name, resp.content)
+
+    async def async_call(self, action_name, http_auth=None, http_headers=None):
+        """
+        Construct the XML and make the call to the device. Parse the response values into a dict.
+        """
+        headers, body = self._create_request(action_name, http_headers=http_headers)
+
+        async with self.session.post(
+            self.url, data=body, headers=headers, timeout=SOAP_TIMEOUT, auth=http_auth
+        ) as resp:
+            try:
+                resp.raise_for_status()
+            except requests.exceptions.HTTPError as exc:
+                # If the body of the error response contains XML then it should be a UPnP error,
+                # otherwise reraise the HTTPError.
+                try:
+                    err_xml = etree.fromstring(await exc.response.read())
+                except etree.XMLSyntaxError:
+                    raise exc
+                raise SOAPError(*self._extract_upnperror(err_xml))
+            return self._parse_response(action_name, await resp.read())

--- a/upnpclient/upnp.py
+++ b/upnpclient/upnp.py
@@ -133,6 +133,8 @@ class Device(CallActionMixin):
 
         if use_async:
             self.session = session or aiohttp.ClientSession()
+            if self.http_auth:
+                self.http_auth = aiohttp.helpers.BasicAuth(*http_auth)
         else:
             self.session = None
             data = self._get_device_description()


### PR DESCRIPTION
Hello! First of all, I love this interface for working with UPnP devices!  It is very intuitive and has excellent built-in documentation, error-handling and tests.

For my needs I was wanting async capability, so here goes.  This is a big change and I will continue to update this PR with tests, refactoring, and other changes from the community.  I thought it was best to get it out there for feedback since I am just learning Python's asyncio and I probably did some weird stuff!

## Python 2
I missed that this library maintained Python 2 support (forever?)  Obviously that won't work for this async stuff.  Would you consider a separate release on PyPI or allowing me to fork and release to PyPI under "aioupnpclient"?  Not sure how to navigate this!

##  Scope and Intentions
- Maintain complete backwards compatibility - should be 100% transparent to libraries and users that update
- Incorporate asyncio with a similar, if not identical, interface to the original
- Flag asyncio option at constructor of Device class
- An aiohttp.ClientSession instance is given as an optional `session` kwarg else it is created by constructor
- This aiohttp.ClientSession is passed down to Service, Action, and SOAP instances that need to make async requests
- AsyncAction class was added so that the action interface has an `async __call__` - note that I could not figure out a way to allow for both synchronous and asynchronous `__call__` from the same instance

## Usage
Requires Python 3.8 to use this asyncio REPL
```python3
python3 -m asyncio
import upnpclient
d = upnpclient.Device(host_resource_url, use_async=True)
await d.async_init()  # first big difference - use the async_init() to set Device attributes
await d.RenderingControl.GetCurrentState()  # call actions using the await keyword
```

## How
If use_async=True is not set when initializing a Device the constructor will execute the original synchronous IO.
See line 134 of upnp.py:
```Python3
def Device:
    ...
    def __init__():
        ...
        if use_async:
            self.session = session or aiohttp.ClientSession()
        else:
            self.session = None
            data = self._get_device_description()
            self._set_device_attributes(data)
            self._read_services()
```
## Questions
I have not used Poetry before and it really made a mess of the poetry.lock file by updating all the dependencies.  All I want to add is the aiohttp dependency.  I did not include the file in the PR for now.

## TODO
- ~~tests to cover the async methods~~
- fix the poetry stuff
- break apart upnp.py?  service.py and action.py?
- add async discovery?
- add an async example to examples?
- ~~test with py3.6 and py3.7 interpreters~~