### PR TITLE
start implementation of UPnP-gw-DeviceProtection-V1

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,3 +180,26 @@ device.Layer3Forwarding1.GetDefaultConnectionService(
 
 If you've set either at `Device` level, they can be overridden per-call by
 setting them to `None`.
+
+
+#### HTTPS Certificate
+
+UPnP DeviceProtection:1 Standardized secured SSL connection to Devices:
+[UPnP-gw-DeviceProtection-V1-Service](http://upnp.org/specs/gw/UPnP-gw-DeviceProtection-V1-Service.pdf)
+from §1.1.2: `Devices and Control Points will generate their own CA certificates`
+
+To be able to connect to those protected Devices, you must add `AllowSelfSignedSSL` kwargs:
+
+```python
+device = upnpclient.Device(
+    "https://192.168.1.1:5000/rootDesc.xml"
+    AllowSelfSignedSSL=True
+)
+```
+Or
+
+```python
+devices = upnpclient.discover(AllowSelfSignedSSL=True)
+```
+
+Note1: At the moment, upnpclient will not try to access the SSL URL (described in §2.3.1 as `SECURELOCATION.UPNP.ORG` header extentson)

--- a/README.md
+++ b/README.md
@@ -184,22 +184,60 @@ setting them to `None`.
 
 #### HTTPS Certificate
 
-UPnP DeviceProtection:1 Standardized secured SSL connection to Devices:
+UPnP DeviceProtection:1 Standardized secured SSL connection to Devices (server):
 [UPnP-gw-DeviceProtection-V1-Service](http://upnp.org/specs/gw/UPnP-gw-DeviceProtection-V1-Service.pdf)
-from §1.1.2: `Devices and Control Points will generate their own CA certificates`
 
-To be able to connect to those protected Devices, you must add `AllowSelfSignedSSL` kwargs:
+From §1.1.2: `Devices and Control Points will generate their own CA certificates`.
+
+This means two things:
+- your control-point (client) must accept Device (server) certificate, which might not be signed by trusted autorithy - eg self-signed.
+- your control-point (client) must provide a certificate to the Device (server), wich also can be self-signed.
+
+In order to do that, two paramters have been added to kwargs:
+- `AllowSelfSignedSSL`: a boolean allowing upnpclient to connect to not-trusted devices
+- `cert`: to allow user-provided certificate to be used for connection
 
 ```python
+mycert = ("C:\\fooo.crt", "C:\\fooo.key")
 device = upnpclient.Device(
-    "https://192.168.1.1:5000/rootDesc.xml"
-    AllowSelfSignedSSL=True
+    "https://192.168.1.1:5000/rootDesc.xml",
+    AllowSelfSignedSSL = True,
+	cert = mycert,
 )
 ```
+
 Or
 
 ```python
-devices = upnpclient.discover(AllowSelfSignedSSL=True)
+devices = upnpclient.discover(AllowSelfSignedSSL=True,AllowSelfSignedSSL = True,cert = mycert)
 ```
 
-Note1: At the moment, upnpclient will not try to access the SSL URL (described in §2.3.1 as `SECURELOCATION.UPNP.ORG` header extentson)
+Note: At the moment, upnpclient will not try to access the SSL URL in discover mode (described in §2.3.1 as `SECURELOCATION.UPNP.ORG` header extension)
+
+
+#### Custom SSDP inbound port 
+
+SSDP protocol is not well supported by firewalls (like netfilter/conntrack) so if you run this control-point client on a critical device, you may have problems setting filter rules.
+
+Main problem is the defaut SSDP behavior which use random inbound UDP port to receive SSDP responses.
+
+To address that problem, we add a workaround option that let you fix this udp input port:
+
+```python
+device = upnpclient.Device(
+    "https://192.168.1.1:5000/rootDesc.xml",
+	SSDPInPort=20000
+)
+```
+
+Or
+
+```python
+devices = upnpclient.discover(AllowSelfSignedSSL=True,SSDPInPort=30000)
+```
+
+Then you can allow this path in your firewall configuration.
+
+Example for iptables:
+
+```iptables -A INPUT [-i <<control-point input interface>>] -d <<control-point ip address>>  -p udp --dport <<control-point fixed ssdp input port>> -j ACCEPT```

--- a/README.md
+++ b/README.md
@@ -184,22 +184,55 @@ setting them to `None`.
 
 #### HTTPS Certificate
 
-UPnP DeviceProtection:1 Standardized secured SSL connection to Devices:
+UPnP DeviceProtection:1 Standardized secured SSL connection to Devices (server):
 [UPnP-gw-DeviceProtection-V1-Service](http://upnp.org/specs/gw/UPnP-gw-DeviceProtection-V1-Service.pdf)
-from §1.1.2: `Devices and Control Points will generate their own CA certificates`
+From §1.1.2: `Devices and Control Points will generate their own CA certificates`.
+This means two things:
+- your control-point (client) must accept Device (server) certificate, which might not be signed by trusted autorithy - eg self-signed.
+- your control-point (client) must provide a certificate to the Device (server), wich also can be self-signed.
 
-To be able to connect to those protected Devices, you must add `AllowSelfSignedSSL` kwargs:
+In order to do that, two paramters have been added to kwargs:
+- `AllowSelfSignedSSL`: a boolean allowing upnpclient to connect to not-trusted devices
+- `cert`: to allow user-provided certificate to be used for connection
 
 ```python
+mycert = ("C:\\fooo.crt", "C:\\fooo.key")
 device = upnpclient.Device(
-    "https://192.168.1.1:5000/rootDesc.xml"
-    AllowSelfSignedSSL=True
+    "https://192.168.1.1:5000/rootDesc.xml",
+    AllowSelfSignedSSL = True,
+	cert = mycert,
 )
 ```
+
 Or
 
 ```python
-devices = upnpclient.discover(AllowSelfSignedSSL=True)
+devices = upnpclient.discover(AllowSelfSignedSSL=True,AllowSelfSignedSSL = True,cert = mycert)
 ```
 
-Note1: At the moment, upnpclient will not try to access the SSL URL (described in §2.3.1 as `SECURELOCATION.UPNP.ORG` header extentson)
+Note: At the moment, upnpclient will not try to access the SSL URL in discover mode (described in §2.3.1 as `SECURELOCATION.UPNP.ORG` header extension)
+
+
+#### Custom SSDP inbound port 
+
+SSDP protocol is not well supported by firewalls (like netfilter/conntrack) so if you run this control-point client on a critical device, you may have problems setting filter rules.
+Main problem is the defaut SSDP behavior which use random inbound UDP port to receive SSDP responses.
+
+To address that problem, we add a workaround option that let you fix this udp input port:
+
+```python
+device = upnpclient.Device(
+    "https://192.168.1.1:5000/rootDesc.xml",
+	SSDPInPort=20000
+)
+```
+
+Or
+
+```python
+devices = upnpclient.discover(AllowSelfSignedSSL=True,SSDPInPort=30000)
+```
+
+Then you can allow this path in your firewall configuration.
+Example for iptables:
+```iptables -A INPUT [-i <<control-point input interface>>] -d <<control-point ip address>>  -p udp --dport <<control-point fixed ssdp input port>> -j ACCEPT```

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ mycert = ("C:\\fooo.crt", "C:\\fooo.key")
 device = upnpclient.Device(
     "https://192.168.1.1:5000/rootDesc.xml",
     AllowSelfSignedSSL = True,
-	cert = mycert,
+    cert = mycert,
 )
 ```
 
@@ -226,7 +226,7 @@ To address that problem, we add a workaround option that let you fix this udp in
 ```python
 device = upnpclient.Device(
     "https://192.168.1.1:5000/rootDesc.xml",
-	SSDPInPort=20000
+    SSDPInPort=20000
 )
 ```
 

--- a/upnpclient/soap.py
+++ b/upnpclient/soap.py
@@ -35,6 +35,10 @@ class SOAP(object):
         ]  # Get hostname portion of url
         self._log = _getLogger("SOAP")
         
+        self.ClientCert = None
+        if "ClientCert" in kwargs:
+            self.ClientCert = kwargs["ClientCert"]
+            
         self.AllowSelfSignedSSL = False
         if "AllowSelfSignedSSL" in kwargs:
             self.AllowSelfSignedSSL = kwargs["AllowSelfSignedSSL"]
@@ -109,7 +113,7 @@ class SOAP(object):
 
         try:
             resp = requests.post(
-                self.url, body, headers=headers, timeout=SOAP_TIMEOUT, auth=http_auth, verify=not(self.AllowSelfSignedSSL)
+                self.url, body, headers=headers, timeout=SOAP_TIMEOUT, auth=http_auth,cert=self.ClientCert, verify=not(self.AllowSelfSignedSSL)
             )
             resp.raise_for_status()
         except requests.exceptions.HTTPError as exc:

--- a/upnpclient/soap.py
+++ b/upnpclient/soap.py
@@ -26,7 +26,8 @@ class SOAP(object):
     This class defines a simple SOAP client.
     """
 
-    def __init__(self, url, service_type,**kwargs):
+    def __init__(self,action, url, service_type,**kwargs):
+        self.action = action
         self.url = url
         self.service_type = service_type
         # FIXME: Use urlparse for this:
@@ -112,7 +113,7 @@ class SOAP(object):
         headers.update(http_headers or {})
 
         try:
-            resp = requests.post(
+            resp = self.action.service.device.session.post(
                 self.url, body, headers=headers, timeout=SOAP_TIMEOUT, auth=http_auth,cert=self.ClientCert, verify=not(self.AllowSelfSignedSSL)
             )
             resp.raise_for_status()

--- a/upnpclient/soap.py
+++ b/upnpclient/soap.py
@@ -26,7 +26,7 @@ class SOAP(object):
     This class defines a simple SOAP client.
     """
 
-    def __init__(self, url, service_type):
+    def __init__(self, url, service_type,**kwargs):
         self.url = url
         self.service_type = service_type
         # FIXME: Use urlparse for this:
@@ -34,6 +34,10 @@ class SOAP(object):
             0
         ]  # Get hostname portion of url
         self._log = _getLogger("SOAP")
+        
+        self.AllowSelfSignedSSL = False
+        if "AllowSelfSignedSSL" in kwargs:
+            self.AllowSelfSignedSSL = kwargs["AllowSelfSignedSSL"]
 
     def _extract_upnperror(self, err_xml):
         """
@@ -105,7 +109,7 @@ class SOAP(object):
 
         try:
             resp = requests.post(
-                self.url, body, headers=headers, timeout=SOAP_TIMEOUT, auth=http_auth
+                self.url, body, headers=headers, timeout=SOAP_TIMEOUT, auth=http_auth, verify=not(self.AllowSelfSignedSSL)
             )
             resp.raise_for_status()
         except requests.exceptions.HTTPError as exc:

--- a/upnpclient/ssdp.py
+++ b/upnpclient/ssdp.py
@@ -33,17 +33,21 @@ def ssdp_request(ssdp_st, ssdp_mx=SSDP_MX):
     ).encode("utf-8")
 
 
-def scan(timeout=5):
+def scan(timeout=5,**kwargs):
     urls = []
     sockets = []
     ssdp_requests = [ssdp_request(ST_ALL), ssdp_request(ST_ROOTDEVICE)]
     stop_wait = datetime.now() + timedelta(seconds=timeout)
+    
+    SSDPInPort = 0
+    if "SSDPInPort" in kwargs:
+        SSDPInPort = kwargs["SSDPInPort"]
 
     for addr in get_addresses_ipv4():
         try:
             sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
             sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, SSDP_MX)
-            sock.bind((addr, 0))
+            sock.bind((addr, SSDPInPort))
             sockets.append(sock)
         except socket.error:
             pass
@@ -114,9 +118,9 @@ def discover(timeout=5,**kwargs):
     Convenience method to discover UPnP devices on the network. Returns a
     list of `upnp.Device` instances. Any invalid servers are silently
     ignored.
-    """
+    """    
     devices = {}
-    for entry in scan(timeout):
+    for entry in scan(timeout,**kwargs):
         if entry.location in devices:
             continue
         try:

--- a/upnpclient/ssdp.py
+++ b/upnpclient/ssdp.py
@@ -109,7 +109,7 @@ def get_addresses_ipv4():
     )
 
 
-def discover(timeout=5):
+def discover(timeout=5,**kwargs):
     """
     Convenience method to discover UPnP devices on the network. Returns a
     list of `upnp.Device` instances. Any invalid servers are silently
@@ -120,7 +120,7 @@ def discover(timeout=5):
         if entry.location in devices:
             continue
         try:
-            devices[entry.location] = Device(entry.location)
+            devices[entry.location] = Device(entry.location,**kwargs)
         except Exception as exc:
             log = _getLogger("ssdp")
             log.error("Error '%s' for %s", exc, entry)

--- a/upnpclient/upnp.py
+++ b/upnpclient/upnp.py
@@ -110,12 +110,16 @@ class Device(CallActionMixin):
         self.http_headers = http_headers
         
         
+        self.ClientCert = None
+        if "ClientCert" in kwargs:
+            self.ClientCert = kwargs["ClientCert"]
+            
         self.AllowSelfSignedSSL = False
         if "AllowSelfSignedSSL" in kwargs:
             self.AllowSelfSignedSSL = kwargs["AllowSelfSignedSSL"]
-
+        print(self.ClientCert)
         resp = requests.get(
-            location, timeout=HTTP_TIMEOUT, auth=self.http_auth, headers=self.http_headers, verify=not(self.AllowSelfSignedSSL)
+            location, timeout=HTTP_TIMEOUT, auth=self.http_auth, headers=self.http_headers,cert=self.ClientCert, verify=not(self.AllowSelfSignedSSL)
         )
         resp.raise_for_status()
 
@@ -253,6 +257,7 @@ class Service(CallActionMixin):
             timeout=HTTP_TIMEOUT,
             auth=self.device.http_auth,
             headers=self.device.http_headers,
+            cert=self.device.ClientCert,
             verify=not(self.device.AllowSelfSignedSSL)
         )
         resp.raise_for_status()
@@ -406,7 +411,7 @@ class Service(CallActionMixin):
         if timeout is not None:
             headers["TIMEOUT"] = "Second-%s" % timeout
         resp = requests.request(
-            "SUBSCRIBE", url, headers=headers, auth=self.device.http_auth, verify=not(self.device.AllowSelfSignedSSL)
+            "SUBSCRIBE", url, headers=headers, auth=self.device.http_auth,cert=self.ClientCert, verify=not(self.device.AllowSelfSignedSSL)
         )
         resp.raise_for_status()
         return Service.validate_subscription_response(resp)
@@ -420,7 +425,7 @@ class Service(CallActionMixin):
         if timeout is not None:
             headers["TIMEOUT"] = "Second-%s" % timeout
         resp = requests.request(
-            "SUBSCRIBE", url, headers=headers, auth=self.device.http_auth, verify=not(self.device.AllowSelfSignedSSL)
+            "SUBSCRIBE", url, headers=headers, auth=self.device.http_auth,cert=self.ClientCert, verify=not(self.device.AllowSelfSignedSSL)
         )
         resp.raise_for_status()
         return Service.validate_subscription_renewal_response(resp)
@@ -432,7 +437,7 @@ class Service(CallActionMixin):
         url = urljoin(self._url_base, self._event_sub_url)
         headers = dict(HOST=urlparse(url).netloc, SID=sid)
         resp = requests.request(
-            "UNSUBSCRIBE", url, headers=headers, auth=self.device.http_auth, verify=not(self.device.AllowSelfSignedSSL)
+            "UNSUBSCRIBE", url, headers=headers, auth=self.device.http_auth,cert=self.ClientCert, verify=not(self.device.AllowSelfSignedSSL)
         )
         resp.raise_for_status()
 


### PR DESCRIPTION
This patch will allow connection to SSL device with self-signed certificate, as explained in UPnP-gw-DeviceProtection-V1-Service specifications.

Its working but will raise a few warning from sublibrary (because of self-signed warning).

Next step: 
- SSDP parser will be updated to fetch 'SECURELOCATION.UPNP.ORG' field and SOAP to use it if available